### PR TITLE
docs: sync workflow before new issues (#3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Before you start work on a **new** GitHub issue, sync with `main` and use a dedicated branch so changes land through a pull request.
+
+## Workflow
+
+1. **Checkout `main`**
+
+   ```bash
+   git checkout main
+   ```
+
+2. **Pull the latest changes from `origin/main`**
+
+   ```bash
+   git pull origin main
+   ```
+
+3. **Create a branch for the issue** (pick a name that matches the issue, for example `issue/42-short-description`)
+
+   ```bash
+   git checkout -b your-branch-name
+   ```
+
+4. **Make the required changes and commit them**
+
+   ```bash
+   git add …
+   git commit -m "Describe the change"
+   ```
+
+5. **Push the branch to the remote**
+
+   ```bash
+   git push -u origin your-branch-name
+   ```
+
+6. **Open a pull request targeting `main`**  
+   Use the GitHub web UI, or [GitHub CLI](https://cli.github.com/):
+
+   ```bash
+   gh pr create --base main --head your-branch-name
+   ```
+
+Keeping `main` up to date before branching reduces merge conflicts and keeps review focused on the issue you are solving.

--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ Backend server made in **Node.js**:
    <img src="image-9.png" alt="pokemon game initial state" width="200"/>
    <img src="image-8.png" alt="pokemon game going right" width="200"/>
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to sync with `main`, branch, and open pull requests before starting new work.


### PR DESCRIPTION
Documents the contributor workflow from GitHub issue #3: checkout `main`, pull `origin/main`, branch, commit, push, and open a PR to `main`.

Adds `CONTRIBUTING.md` with concrete git (and optional `gh`) commands, and a short link from the README.

Closes #3.

Made with [Cursor](https://cursor.com)