### PR TITLE
feat: Slice: node:test suite for orchestrator decision logic (mo… (#15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test ./test/**/*.test.js",
     "start": "node --no-deprecation whatsapp.js",
     "start:joplin": "node --no-deprecation test-joplin.js"
   },

--- a/test/cursorPostRunOrchestrator.test.js
+++ b/test/cursorPostRunOrchestrator.test.js
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+import {
+  VERDICT_APPROVE,
+  VERDICT_REQUEST_CHANGES,
+  autoMergeAllowedByReviewGate,
+  pickPrResultAfterGhFlow,
+  normalizePrReviewComment,
+} from '../whatsapp/agents/cursorPostRunDecisionLogic.js';
+import { pollGithubIssueClosedOrTimeout } from '../whatsapp/agents/cursorPostRunIssuePoll.js';
+import { runPostReviewAutofixMergeFlow } from '../whatsapp/agents/cursorPostRunReviewFollowUp.js';
+
+describe('cursorPostRun decision logic', () => {
+  it('VERDICT: APPROVE with successful review enables auto-merge gate without autofix', () => {
+    assert.equal(
+      autoMergeAllowedByReviewGate({
+        reviewOutcome: 'success',
+        reviewVerdict: VERDICT_APPROVE,
+        postReviewAutofix: null,
+      }),
+      true
+    );
+  });
+
+  it('VERDICT: REQUEST_CHANGES does not enable auto-merge until autofix succeeds', () => {
+    assert.equal(
+      autoMergeAllowedByReviewGate({
+        reviewOutcome: 'success',
+        reviewVerdict: VERDICT_REQUEST_CHANGES,
+        postReviewAutofix: null,
+      }),
+      false
+    );
+    assert.equal(
+      autoMergeAllowedByReviewGate({
+        reviewOutcome: 'success',
+        reviewVerdict: VERDICT_REQUEST_CHANGES,
+        postReviewAutofix: { ok: false, mergeBlocked: true },
+      }),
+      false
+    );
+    assert.equal(
+      autoMergeAllowedByReviewGate({
+        reviewOutcome: 'success',
+        reviewVerdict: VERDICT_REQUEST_CHANGES,
+        postReviewAutofix: { ok: true, mergeBlocked: false },
+      }),
+      true
+    );
+  });
+
+  it('autofix failure / no-op path blocks auto-merge (mergeBlocked implies ok false)', () => {
+    assert.equal(
+      autoMergeAllowedByReviewGate({
+        reviewOutcome: 'success',
+        reviewVerdict: VERDICT_REQUEST_CHANGES,
+        postReviewAutofix: { ok: false, mergeBlocked: true, detail: 'no changes' },
+      }),
+      false
+    );
+  });
+
+  it('PR "already exists" still yields a usable PR URL via recovery', () => {
+    const picked = pickPrResultAfterGhFlow({
+      listedOk: false,
+      createOk: false,
+      createError: 'GraphQL: A pull request already exists for cursor:branch',
+      recoveredUrl: 'https://github.com/o/r/pull/99',
+    });
+    assert.equal(picked.ok, true);
+    assert.equal(picked.url, 'https://github.com/o/r/pull/99');
+    assert.equal(picked.prOutcome, 'recovered');
+  });
+
+  it('normalizePrReviewComment defaults invalid first lines to REQUEST_CHANGES', () => {
+    const n = normalizePrReviewComment('not a verdict\n\nbody');
+    assert.equal(n.verdict, VERDICT_REQUEST_CHANGES);
+    assert.match(n.fullComment, /VERDICT: REQUEST_CHANGES/);
+  });
+});
+
+describe('issue close polling (no live GitHub)', () => {
+  it('times out without throwing when the issue never closes', async () => {
+    let t = 0;
+    const now = () => t;
+    const sleep = mock.fn(async (ms) => {
+      t += ms;
+    });
+    const fetchState = async () => ({ ok: true, state: 'OPEN' });
+    const result = await pollGithubIssueClosedOrTimeout({
+      maxWaitMs: 45,
+      pollMs: 10,
+      fetchState,
+      sleep,
+      now,
+    });
+    assert.equal(result.closed, false);
+    assert.equal(result.timedOut, true);
+    assert.ok(result.waitedMs >= 45);
+    assert.ok(sleep.mock.callCount() >= 4);
+  });
+
+  it('returns closed when fetchState reports CLOSED before timeout', async () => {
+    let n = 0;
+    const fetchState = async () => {
+      n++;
+      return n >= 2 ? { ok: true, state: 'CLOSED' } : { ok: true, state: 'OPEN' };
+    };
+    const result = await pollGithubIssueClosedOrTimeout({
+      maxWaitMs: 500,
+      pollMs: 0,
+      fetchState,
+      sleep: async () => {},
+      now: () => 0,
+    });
+    assert.equal(result.closed, true);
+    assert.equal(result.timedOut, false);
+  });
+});
+
+describe('runPostReviewAutofixMergeFlow (mocked gh + agent)', () => {
+  it('REQUEST_CHANGES triggers exactly one autofix invocation', async () => {
+    let autofixCalls = 0;
+    const runSinglePostReviewAutofix = async () => {
+      autofixCalls++;
+      return { ok: true, mergeBlocked: false, detail: 'ok' };
+    };
+    const tryGhPrMergeAutoSquash = mock.fn(async () => ({ ok: true }));
+    const tryGhPrReviewComment = mock.fn(async () => ({ ok: true }));
+    const waitForGithubIssueClosed = mock.fn(async () => ({
+      closed: false,
+      timedOut: true,
+      waitedMs: 0,
+      polls: 0,
+    }));
+
+    await runPostReviewAutofixMergeFlow({
+      repo: '/tmp/repo',
+      issueNum: 15,
+      userPrompt: 'x',
+      prResult: { ok: true, url: 'https://github.com/o/r/pull/1' },
+      reviewOutcome: 'success',
+      reviewVerdict: VERDICT_REQUEST_CHANGES,
+      reviewBodyMarkdown: 'fix it',
+      postReviewAutofixEnabled: () => true,
+      prAutoMergeAfterReviewEnabled: () => true,
+      prAfterPushEnabled: () => true,
+      commitOk: true,
+      pushResultOk: true,
+      runSinglePostReviewAutofix,
+      tryGhPrReviewComment,
+      tryGhPrMergeAutoSquash,
+      waitForGithubIssueClosed,
+      logPost: () => {},
+    });
+
+    assert.equal(autofixCalls, 1);
+    assert.equal(tryGhPrMergeAutoSquash.mock.callCount(), 1);
+  });
+
+  it('REQUEST_CHANGES with autofix mergeBlocked skips auto-merge', async () => {
+    const runSinglePostReviewAutofix = async () => ({
+      ok: false,
+      mergeBlocked: true,
+      detail: 'Autofix finished but **git detected no file changes**',
+    });
+    const tryGhPrMergeAutoSquash = mock.fn(async () => ({ ok: true }));
+    const tryGhPrReviewComment = mock.fn(async () => ({ ok: true }));
+    const waitForGithubIssueClosed = mock.fn(async () => ({}));
+
+    await runPostReviewAutofixMergeFlow({
+      repo: '/tmp/repo',
+      issueNum: 2,
+      userPrompt: 'x',
+      prResult: { ok: true, url: 'https://github.com/o/r/pull/2' },
+      reviewOutcome: 'success',
+      reviewVerdict: VERDICT_REQUEST_CHANGES,
+      reviewBodyMarkdown: 'x',
+      postReviewAutofixEnabled: () => true,
+      prAutoMergeAfterReviewEnabled: () => true,
+      prAfterPushEnabled: () => true,
+      commitOk: true,
+      pushResultOk: true,
+      runSinglePostReviewAutofix,
+      tryGhPrReviewComment,
+      tryGhPrMergeAutoSquash,
+      waitForGithubIssueClosed,
+      logPost: () => {},
+    });
+
+    assert.equal(tryGhPrMergeAutoSquash.mock.callCount(), 0);
+    assert.ok(tryGhPrReviewComment.mock.callCount() >= 1);
+  });
+
+  it('APPROVE runs auto-merge without calling autofix', async () => {
+    const runSinglePostReviewAutofix = mock.fn(async () => ({ ok: true, mergeBlocked: false, detail: '' }));
+    const tryGhPrMergeAutoSquash = mock.fn(async () => ({ ok: true }));
+    const tryGhPrReviewComment = mock.fn(async () => ({ ok: true }));
+    const waitForGithubIssueClosed = mock.fn(async () => ({
+      closed: false,
+      timedOut: true,
+      waitedMs: 1,
+      polls: 1,
+    }));
+
+    await runPostReviewAutofixMergeFlow({
+      repo: '/tmp/repo',
+      issueNum: 3,
+      userPrompt: 'x',
+      prResult: { ok: true, url: 'https://github.com/o/r/pull/3' },
+      reviewOutcome: 'success',
+      reviewVerdict: VERDICT_APPROVE,
+      reviewBodyMarkdown: '',
+      postReviewAutofixEnabled: () => true,
+      prAutoMergeAfterReviewEnabled: () => true,
+      prAfterPushEnabled: () => true,
+      commitOk: true,
+      pushResultOk: true,
+      runSinglePostReviewAutofix,
+      tryGhPrReviewComment,
+      tryGhPrMergeAutoSquash,
+      waitForGithubIssueClosed,
+      logPost: () => {},
+    });
+
+    assert.equal(runSinglePostReviewAutofix.mock.callCount(), 0);
+    assert.equal(tryGhPrMergeAutoSquash.mock.callCount(), 1);
+  });
+});

--- a/whatsapp/agents/cursorPostRun.js
+++ b/whatsapp/agents/cursorPostRun.js
@@ -9,13 +9,20 @@ import nodemailer from 'nodemailer';
 import { logAgentInvocation, addCompletionUsage } from './agentUsageLog.js';
 import { runCursorCliAgent } from './cursorCliAgent.js';
 import { deepInfra } from '../../models/models.js';
+import {
+  VERDICT_APPROVE,
+  VERDICT_REQUEST_CHANGES,
+  ghMessageLooksLikePrAlreadyExists,
+  normalizePrReviewComment,
+  autoMergeAllowedByReviewGate,
+  pickPrResultAfterGhFlow,
+} from './cursorPostRunDecisionLogic.js';
+import { pollGithubIssueClosedOrTimeout } from './cursorPostRunIssuePoll.js';
+import { runPostReviewAutofixMergeFlow } from './cursorPostRunReviewFollowUp.js';
 
 dotenv.config();
 
 const execFileAsync = promisify(execFile);
-
-const VERDICT_APPROVE = 'VERDICT: APPROVE';
-const VERDICT_REQUEST_CHANGES = 'VERDICT: REQUEST_CHANGES';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -367,15 +374,6 @@ async function tryGhFirstOpenPrUrlForHead(repo, head) {
   }
 }
 
-function ghMessageLooksLikePrAlreadyExists(msg) {
-  const s = String(msg || '').toLowerCase();
-  return (
-    s.includes('already exists') ||
-    s.includes('pull request already') ||
-    (s.includes('a pull request') && s.includes('already'))
-  );
-}
-
 /** GitHub caps issue/PR comments well below 64 KiB; stay under with margin. */
 const GITHUB_PR_COMMENT_MAX_CHARS = 62000;
 
@@ -501,52 +499,12 @@ async function tryGhIssueViewDetails(repo, issueNumber) {
 async function waitForGithubIssueClosed(repo, issueNumber, opts = {}) {
   const maxWaitMs = Number.isFinite(opts.maxWaitMs) ? opts.maxWaitMs : ISSUE_CLOSE_MAX_WAIT_MS;
   const pollMs = Number.isFinite(opts.pollMs) ? opts.pollMs : ISSUE_CLOSE_POLL_MS;
-  const start = Date.now();
-  let polls = 0;
-  let lastError = '';
-
-  while (Date.now() - start < maxWaitMs) {
-    polls++;
-    const r = await tryGhIssueViewState(repo, issueNumber);
-    if (!r.ok) {
-      lastError = r.error || '';
-      logPost(`issue #${issueNumber} poll failed`, lastError);
-    } else if (r.state === 'CLOSED') {
-      return {
-        closed: true,
-        timedOut: false,
-        waitedMs: Date.now() - start,
-        polls,
-        lastState: r.state,
-      };
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-
-  const final = await tryGhIssueViewState(repo, issueNumber);
-  const lastState = final.ok ? final.state || '' : '';
-  if (!final.ok) lastError = final.error || lastError;
-  const closed = lastState === 'CLOSED';
-  return {
-    closed,
-    timedOut: !closed,
-    waitedMs: Date.now() - start,
-    polls,
-    lastState,
-    lastError: final.ok ? '' : lastError,
-  };
-}
-
-/**
- * @param {{ reviewOutcome: string, reviewVerdict: string, postReviewAutofix: { ok?: boolean } | null }} args
- */
-function autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix }) {
-  if (reviewOutcome !== 'success') return false;
-  if (reviewVerdict === VERDICT_APPROVE) return true;
-  if (reviewVerdict === VERDICT_REQUEST_CHANGES) {
-    return Boolean(postReviewAutofix?.ok);
-  }
-  return false;
+  return pollGithubIssueClosedOrTimeout({
+    maxWaitMs,
+    pollMs,
+    fetchState: () => tryGhIssueViewState(repo, issueNumber),
+    onPollError: (d) => logPost(`issue #${issueNumber} poll failed`, d.error),
+  });
 }
 
 /**
@@ -760,39 +718,6 @@ function truncate(s, max) {
   const t = String(s);
   if (t.length <= max) return t;
   return `${t.slice(0, max)}\n\n[… truncated at ${max} characters …]\n`;
-}
-
-/**
- * Ensure the GitHub PR comment starts with an exact verdict line (automation-parseable).
- * @param {string} raw model output
- * @returns {{ verdict: typeof VERDICT_APPROVE | typeof VERDICT_REQUEST_CHANGES, bodyMarkdown: string, fullComment: string }}
- */
-function normalizePrReviewComment(raw) {
-  const text = String(raw || '').trim();
-  const lines = text.split(/\r?\n/);
-  let i = 0;
-  while (i < lines.length && !lines[i].trim()) i++;
-  const first = (lines[i] || '').trim();
-  const rest = lines.slice(i + 1).join('\n').trim();
-
-  const up = first.toUpperCase();
-  if (up === VERDICT_APPROVE.toUpperCase()) {
-    const fullComment = rest ? `${VERDICT_APPROVE}\n\n${rest}` : `${VERDICT_APPROVE}\n`;
-    return { verdict: VERDICT_APPROVE, bodyMarkdown: rest, fullComment };
-  }
-  if (up === VERDICT_REQUEST_CHANGES.toUpperCase()) {
-    const fullComment = rest ? `${VERDICT_REQUEST_CHANGES}\n\n${rest}` : `${VERDICT_REQUEST_CHANGES}\n`;
-    return { verdict: VERDICT_REQUEST_CHANGES, bodyMarkdown: rest, fullComment };
-  }
-
-  const body =
-    text ||
-    '_The model returned an empty review._';
-  const fallbackBody =
-    '_The automated reviewer did not put a valid verdict on the first line; defaulting to REQUEST_CHANGES._\n\n' +
-    body;
-  const fullComment = `${VERDICT_REQUEST_CHANGES}\n\n${fallbackBody}`;
-  return { verdict: VERDICT_REQUEST_CHANGES, bodyMarkdown: fallbackBody, fullComment };
 }
 
 async function getStatusPorcelain(repo) {
@@ -1302,21 +1227,33 @@ export async function maybeCommitReviewEmail(opts) {
           if (!listed.ok) {
             logPost('gh pr list failed (will still try pr create)', listed.error);
           }
-          prResult = await tryGhPrCreate(repo, {
+          const created = await tryGhPrCreate(repo, {
             base: workBranch.prBase,
             title: prTitle,
             body: prBody,
           });
-          logPost('gh pr create result', prResult);
-          if (prResult.ok) {
-            prOutcome = 'created';
-          } else if (ghMessageLooksLikePrAlreadyExists(prResult.error)) {
-            const recovered = await tryGhFirstOpenPrUrlForHead(repo, workBranch.branchName);
-            if (recovered) {
-              prResult = { ok: true, url: recovered };
-              prOutcome = 'recovered';
-              logPost('resolved duplicate PR message; using existing PR', recovered);
+          logPost('gh pr create result', created);
+          let recoveredUrl = null;
+          if (!created.ok && ghMessageLooksLikePrAlreadyExists(created.error)) {
+            recoveredUrl = await tryGhFirstOpenPrUrlForHead(repo, workBranch.branchName);
+            if (recoveredUrl) {
+              logPost('resolved duplicate PR message; using existing PR', recoveredUrl);
             }
+          }
+          const picked = pickPrResultAfterGhFlow({
+            listedOk: false,
+            listedUrl: undefined,
+            createOk: created.ok,
+            createUrl: created.url,
+            createError: created.error,
+            recoveredUrl,
+          });
+          if (picked.ok && picked.url) {
+            prResult = { ok: true, url: picked.url };
+            prOutcome = picked.prOutcome;
+          } else {
+            prResult = created;
+            prOutcome = created.ok ? 'created' : null;
           }
         }
       }
@@ -1346,60 +1283,25 @@ export async function maybeCommitReviewEmail(opts) {
   }
 
   /** Exactly one autofix pass when the model requests changes (issue #12); never loops. */
-  let postReviewAutofix = null;
-  if (
-    postReviewAutofixEnabled() &&
-    reviewVerdict === VERDICT_REQUEST_CHANGES &&
-    reviewOutcome === 'success'
-  ) {
-    const shouldAutofix = commit.ok && Boolean(pushResult?.ok) && Boolean(prResult?.ok);
-    if (shouldAutofix) {
-      postReviewAutofix = await runSinglePostReviewAutofix({
-        repo,
-        issueNum,
-        prUrl: prResult.url,
-        bodyMarkdown: reviewBodyMarkdown,
-        originalUserPrompt: userPrompt,
-      });
-      if (postReviewAutofix.mergeBlocked && prResult.ok) {
-        const gateBody = [
-          '**WhatsApp bot — automated autofix failed**',
-          '',
-          postReviewAutofix.detail,
-          '',
-          '**Do not merge** this PR until the review feedback is addressed (manually or with another `cursor issue:…` run).',
-        ].join('\n');
-        const gateComment = await tryGhPrReviewComment(repo, prResult.url, gateBody);
-        logPost('post-review autofix merge-gate PR comment', gateComment);
-      }
-    } else {
-      logPost('post-review autofix skipped (needs successful commit, push, and open PR)', {
-        commitOk: commit.ok,
-        pushOk: Boolean(pushResult?.ok),
-        prOk: Boolean(prResult?.ok),
-      });
-    }
-  }
-
-  /** @type {{ ok: boolean, error?: string } | null} */
-  let prAutoMergeResult = null;
-  /** @type {{ closed: boolean, timedOut: boolean, waitedMs: number, polls: number, lastState?: string, lastError?: string } | null} */
-  let issueCloseWait = null;
-  if (
-    prAutoMergeAfterReviewEnabled() &&
-    prAfterPushEnabled() &&
-    prResult?.ok &&
-    autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix })
-  ) {
-    prAutoMergeResult = await tryGhPrMergeAutoSquash(repo, prResult.url);
-    logPost('gh pr merge --auto --squash', prAutoMergeResult);
-    if (prAutoMergeResult.ok) {
-      issueCloseWait = await waitForGithubIssueClosed(repo, issueNum);
-      logPost('wait for issue closed', issueCloseWait);
-    }
-  } else if (prAutoMergeAfterReviewEnabled() && prAfterPushEnabled() && prResult?.ok) {
-    logPost('skip auto-merge (review gate)', { reviewOutcome, reviewVerdict, autofixOk: postReviewAutofix?.ok });
-  }
+  const { postReviewAutofix, prAutoMergeResult, issueCloseWait } = await runPostReviewAutofixMergeFlow({
+    repo,
+    issueNum,
+    userPrompt,
+    prResult,
+    reviewOutcome,
+    reviewVerdict,
+    reviewBodyMarkdown,
+    postReviewAutofixEnabled,
+    prAutoMergeAfterReviewEnabled,
+    prAfterPushEnabled,
+    commitOk: commit.ok,
+    pushResultOk: Boolean(pushResult?.ok),
+    runSinglePostReviewAutofix,
+    tryGhPrReviewComment,
+    tryGhPrMergeAutoSquash,
+    waitForGithubIssueClosed,
+    logPost,
+  });
 
   /** @type {{ ok: boolean, to?: string, error?: string, step?: string } | null} */
   let postCloseChangesEmail = null;

--- a/whatsapp/agents/cursorPostRunDecisionLogic.js
+++ b/whatsapp/agents/cursorPostRunDecisionLogic.js
@@ -1,0 +1,86 @@
+export const VERDICT_APPROVE = 'VERDICT: APPROVE';
+export const VERDICT_REQUEST_CHANGES = 'VERDICT: REQUEST_CHANGES';
+
+/**
+ * After `gh pr create`, pick URL including recovery when GitHub says a PR already exists.
+ * @param {{
+ *   listedOk: boolean,
+ *   listedUrl?: string,
+ *   createOk: boolean,
+ *   createUrl?: string,
+ *   createError?: string,
+ *   recoveredUrl?: string | null,
+ * }} p
+ * @returns {{ ok: boolean, url?: string, error?: string, prOutcome: 'listed' | 'created' | 'recovered' | null }}
+ */
+export function pickPrResultAfterGhFlow(p) {
+  if (p.listedOk && p.listedUrl) {
+    return { ok: true, url: p.listedUrl, prOutcome: 'listed' };
+  }
+  if (p.createOk && p.createUrl) {
+    return { ok: true, url: p.createUrl, prOutcome: 'created' };
+  }
+  if (ghMessageLooksLikePrAlreadyExists(p.createError) && p.recoveredUrl) {
+    return { ok: true, url: p.recoveredUrl, prOutcome: 'recovered' };
+  }
+  return {
+    ok: Boolean(p.createOk),
+    url: p.createUrl,
+    error: p.createError,
+    prOutcome: null,
+  };
+}
+
+export function ghMessageLooksLikePrAlreadyExists(msg) {
+  const s = String(msg || '').toLowerCase();
+  return (
+    s.includes('already exists') ||
+    s.includes('pull request already') ||
+    (s.includes('a pull request') && s.includes('already'))
+  );
+}
+
+/**
+ * @param {{ reviewOutcome: string, reviewVerdict: string, postReviewAutofix: { ok?: boolean } | null }} args
+ */
+export function autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix }) {
+  if (reviewOutcome !== 'success') return false;
+  if (reviewVerdict === VERDICT_APPROVE) return true;
+  if (reviewVerdict === VERDICT_REQUEST_CHANGES) {
+    return Boolean(postReviewAutofix?.ok);
+  }
+  return false;
+}
+
+/**
+ * Ensure the GitHub PR comment starts with an exact verdict line (automation-parseable).
+ * @param {string} raw model output
+ * @returns {{ verdict: typeof VERDICT_APPROVE | typeof VERDICT_REQUEST_CHANGES, bodyMarkdown: string, fullComment: string }}
+ */
+export function normalizePrReviewComment(raw) {
+  const text = String(raw || '').trim();
+  const lines = text.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length && !lines[i].trim()) i++;
+  const first = (lines[i] || '').trim();
+  const rest = lines.slice(i + 1).join('\n').trim();
+
+  const up = first.toUpperCase();
+  if (up === VERDICT_APPROVE.toUpperCase()) {
+    const fullComment = rest ? `${VERDICT_APPROVE}\n\n${rest}` : `${VERDICT_APPROVE}\n`;
+    return { verdict: VERDICT_APPROVE, bodyMarkdown: rest, fullComment };
+  }
+  if (up === VERDICT_REQUEST_CHANGES.toUpperCase()) {
+    const fullComment = rest
+      ? `${VERDICT_REQUEST_CHANGES}\n\n${rest}`
+      : `${VERDICT_REQUEST_CHANGES}\n`;
+    return { verdict: VERDICT_REQUEST_CHANGES, bodyMarkdown: rest, fullComment };
+  }
+
+  const body = text || '_The model returned an empty review._';
+  const fallbackBody =
+    '_The automated reviewer did not put a valid verdict on the first line; defaulting to REQUEST_CHANGES._\n\n' +
+    body;
+  const fullComment = `${VERDICT_REQUEST_CHANGES}\n\n${fallbackBody}`;
+  return { verdict: VERDICT_REQUEST_CHANGES, bodyMarkdown: fallbackBody, fullComment };
+}

--- a/whatsapp/agents/cursorPostRunIssuePoll.js
+++ b/whatsapp/agents/cursorPostRunIssuePoll.js
@@ -1,0 +1,55 @@
+/**
+ * Poll until `fetchState()` reports CLOSED or wall-clock budget is exhausted.
+ * Never throws from poll failures; surfaces last error when the final check fails.
+ *
+ * @param {{
+ *   maxWaitMs: number,
+ *   pollMs: number,
+ *   fetchState: () => Promise<{ ok: boolean, state?: string, error?: string }>,
+ *   sleep?: (ms: number) => Promise<void>,
+ *   now?: () => number,
+ *   onPollError?: (detail: { polls: number, error: string }) => void,
+ * }} opts
+ */
+export async function pollGithubIssueClosedOrTimeout(opts) {
+  const maxWaitMs = Number.isFinite(opts.maxWaitMs) ? opts.maxWaitMs : 0;
+  const pollMs = Number.isFinite(opts.pollMs) ? opts.pollMs : 0;
+  const sleep = opts.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const now = opts.now ?? (() => Date.now());
+  const onPollError = opts.onPollError;
+
+  const start = now();
+  let polls = 0;
+  let lastError = '';
+
+  while (now() - start < maxWaitMs) {
+    polls++;
+    const r = await opts.fetchState();
+    if (!r.ok) {
+      lastError = r.error || '';
+      onPollError?.({ polls, error: lastError });
+    } else if (r.state === 'CLOSED') {
+      return {
+        closed: true,
+        timedOut: false,
+        waitedMs: now() - start,
+        polls,
+        lastState: r.state,
+      };
+    }
+    await sleep(pollMs);
+  }
+
+  const final = await opts.fetchState();
+  const lastState = final.ok ? String(final.state || '').trim().toUpperCase() : '';
+  if (!final.ok) lastError = final.error || lastError;
+  const closed = lastState === 'CLOSED';
+  return {
+    closed,
+    timedOut: !closed,
+    waitedMs: now() - start,
+    polls,
+    lastState,
+    lastError: final.ok ? '' : lastError,
+  };
+}

--- a/whatsapp/agents/cursorPostRunReviewFollowUp.js
+++ b/whatsapp/agents/cursorPostRunReviewFollowUp.js
@@ -1,0 +1,87 @@
+import {
+  VERDICT_REQUEST_CHANGES,
+  autoMergeAllowedByReviewGate,
+} from './cursorPostRunDecisionLogic.js';
+
+/**
+ * Post-LLM-review steps: optional single autofix pass, merge-gate PR comment, auto-merge + issue poll.
+ * Dependencies are injected so `node:test` can mock `gh`, git-backed helpers, and Cursor CLI.
+ */
+export async function runPostReviewAutofixMergeFlow({
+  repo,
+  issueNum,
+  userPrompt,
+  prResult,
+  reviewOutcome,
+  reviewVerdict,
+  reviewBodyMarkdown,
+  postReviewAutofixEnabled,
+  prAutoMergeAfterReviewEnabled,
+  prAfterPushEnabled,
+  commitOk,
+  pushResultOk,
+  runSinglePostReviewAutofix,
+  tryGhPrReviewComment,
+  tryGhPrMergeAutoSquash,
+  waitForGithubIssueClosed,
+  logPost = () => {},
+}) {
+  let postReviewAutofix = null;
+  if (
+    postReviewAutofixEnabled() &&
+    reviewVerdict === VERDICT_REQUEST_CHANGES &&
+    reviewOutcome === 'success'
+  ) {
+    const shouldAutofix = commitOk && Boolean(pushResultOk) && Boolean(prResult?.ok);
+    if (shouldAutofix) {
+      postReviewAutofix = await runSinglePostReviewAutofix({
+        repo,
+        issueNum,
+        prUrl: prResult.url,
+        bodyMarkdown: reviewBodyMarkdown,
+        originalUserPrompt: userPrompt,
+      });
+      if (postReviewAutofix.mergeBlocked && prResult.ok) {
+        const gateBody = [
+          '**WhatsApp bot — automated autofix failed**',
+          '',
+          postReviewAutofix.detail,
+          '',
+          '**Do not merge** this PR until the review feedback is addressed (manually or with another `cursor issue:…` run).',
+        ].join('\n');
+        const gateComment = await tryGhPrReviewComment(repo, prResult.url, gateBody);
+        logPost('post-review autofix merge-gate PR comment', gateComment);
+      }
+    } else {
+      logPost('post-review autofix skipped (needs successful commit, push, and open PR)', {
+        commitOk,
+        pushOk: Boolean(pushResultOk),
+        prOk: Boolean(prResult?.ok),
+      });
+    }
+  }
+
+  let prAutoMergeResult = null;
+  let issueCloseWait = null;
+  if (
+    prAutoMergeAfterReviewEnabled() &&
+    prAfterPushEnabled() &&
+    prResult?.ok &&
+    autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix })
+  ) {
+    prAutoMergeResult = await tryGhPrMergeAutoSquash(repo, prResult.url);
+    logPost('gh pr merge --auto --squash', prAutoMergeResult);
+    if (prAutoMergeResult.ok) {
+      issueCloseWait = await waitForGithubIssueClosed(repo, issueNum);
+      logPost('wait for issue closed', issueCloseWait);
+    }
+  } else if (prAutoMergeAfterReviewEnabled() && prAfterPushEnabled() && prResult?.ok) {
+    logPost('skip auto-merge (review gate)', {
+      reviewOutcome,
+      reviewVerdict,
+      autofixOk: postReviewAutofix?.ok,
+    });
+  }
+
+  return { postReviewAutofix, prAutoMergeResult, issueCloseWait };
+}


### PR DESCRIPTION
Fixes #15

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-15-slice-node-test-suite-for-orchestrator-decision-`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #15

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/15
**State:** OPEN
**Title:** Slice: node:test suite for orchestrator decision logic (mock gh/agent)

## Body
## Parent

#9

## What to build

Add a minimal automated test suite using Node’s built-in `node:test` that verifies the orchestrator’s key decisions by mocking external boundaries (GitHub CLI calls, git calls, and Cursor agent invocation).

## Acceptance criteria

- [ ] Repository has a runnable test command (e.g. `npm test` runs `node --test`)
- [ ] Tests cover core decision logic:
  - [ ] `VERDICT: APPROVE` leads to merge enablement
  - [ ] `VERDICT: REQUEST_CHANGES` triggers exactly one autofix pass
  - [ ] Autofix failure/no-op prevents auto-merge
  - [ ] PR “already exists” path still results in a PR URL being used
  - [ ] Issue close polling timeout is handled without crashing
- [ ] External side effects are mocked (no live GitHub required to run tests)

## Blocked by

- Blocked by #12