### PR TITLE
feat: Single-agent busy lock + reject manual cursor when busy (#24)

### DIFF
--- a/test/cursorAgentBusy.test.js
+++ b/test/cursorAgentBusy.test.js
@@ -1,0 +1,27 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  tryAcquireAgentBusyLock,
+  releaseAgentBusyLock,
+} from '../whatsapp/agents/cursorAgentBusy.js';
+
+describe('cursorAgentBusy lock', () => {
+  beforeEach(() => {
+    releaseAgentBusyLock();
+  });
+
+  it('allows one holder and refuses a second', () => {
+    assert.equal(tryAcquireAgentBusyLock(), true);
+    assert.equal(tryAcquireAgentBusyLock(), false);
+  });
+
+  it('releases in finally so a new run can acquire', () => {
+    assert.equal(tryAcquireAgentBusyLock(), true);
+    try {
+      /* simulate work */
+    } finally {
+      releaseAgentBusyLock();
+    }
+    assert.equal(tryAcquireAgentBusyLock(), true);
+  });
+});

--- a/whatsapp/agents/cursorAgentBusy.js
+++ b/whatsapp/agents/cursorAgentBusy.js
@@ -1,0 +1,16 @@
+/** Process-wide: only one manual WhatsApp `cursor` agent run at a time. */
+
+let busy = false;
+
+/**
+ * @returns {boolean} true if this call holds the lock; false if another run is in progress
+ */
+export function tryAcquireAgentBusyLock() {
+  if (busy) return false;
+  busy = true;
+  return true;
+}
+
+export function releaseAgentBusyLock() {
+  busy = false;
+}

--- a/whatsapp/commands/cursor.js
+++ b/whatsapp/commands/cursor.js
@@ -18,6 +18,10 @@ import {
 import joplinAPI, { WHATSAPP_BOT_NOTEBOOK } from '../../joplin/index.js';
 import { actorJid, isAllowedActor, lidExtraJidsHint } from '../whatsAppActorAllowlist.js';
 import { fetchGhIssuePromptText } from '../agents/ghIssueForCursor.js';
+import {
+  tryAcquireAgentBusyLock,
+  releaseAgentBusyLock,
+} from '../agents/cursorAgentBusy.js';
 
 dotenv.config();
 
@@ -210,183 +214,194 @@ export default async function cursorCommand(sock, sender, text, msg) {
     return;
   }
 
-  let prompt = rawPrompt;
-  let joplinSource = null;
-  let issueSource = null;
-
-  const issueMatch = parseIssuePrefix(rawPrompt);
-  let workspaceAliasForRepo = ws.kind === 'alias' ? ws.alias : null;
-
-  if (issueMatch?.issueAlias && ws.kind === 'default') {
-    try {
-      workspaceRoot = await resolveWorkspaceFromAlias(issueMatch.issueAlias);
-    } catch (e) {
-      await sock.sendMessage(sender, {
-        text: `Cursor workspace: ${e.message || String(e)}`,
-      });
-      return;
-    }
-    workspaceAliasForRepo = issueMatch.issueAlias;
+  if (!tryAcquireAgentBusyLock()) {
+    await sock.sendMessage(sender, {
+      text:
+        'The Cursor agent is already running (issue or freeform). Try again when it finishes.',
+    });
+    return;
   }
+  try {
+    let prompt = rawPrompt;
+    let joplinSource = null;
+    let issueSource = null;
 
-  if (issueMatch) {
-    try {
-      await sock.sendMessage(sender, {
-        text: `Fetching GitHub issue #${issueMatch.issueNumber} …`,
-      });
-      const fetched = await fetchGhIssuePromptText(issueMatch.issueNumber, {
-        extraInstructions: issueMatch.extraInstructions,
-        workspaceRoot,
-        workspaceAlias: workspaceAliasForRepo,
-      });
-      prompt = fetched.markdown;
-      issueSource = {
-        number: fetched.number,
-        repo: fetched.repo,
-        title: fetched.title,
-      };
+    const issueMatch = parseIssuePrefix(rawPrompt);
+    let workspaceAliasForRepo = ws.kind === 'alias' ? ws.alias : null;
+
+    if (issueMatch?.issueAlias && ws.kind === 'default') {
       try {
+        workspaceRoot = await resolveWorkspaceFromAlias(issueMatch.issueAlias);
+      } catch (e) {
         await sock.sendMessage(sender, {
-          text: `Preparing git in ${workspaceRoot}: checkout latest default branch, pull from origin, create issue branch …`,
-        });
-        const prep = await prepareWorkspaceForGithubIssue(
-          workspaceRoot,
-          issueMatch.issueNumber,
-          issueSource.title
-        );
-        await sock.sendMessage(sender, {
-          text: `Ready on branch \`${prep.branchName}\` (synced from \`${prep.defaultBranch}\`).`,
-        });
-      } catch (prepErr) {
-        await sock.sendMessage(sender, {
-          text: `Git setup for issue #${issueMatch.issueNumber} failed: ${prepErr.message || String(prepErr)}`,
+          text: `Cursor workspace: ${e.message || String(e)}`,
         });
         return;
       }
-    } catch (err) {
-      await sock.sendMessage(sender, {
-        text: `Failed to read GitHub issue: ${err.message || String(err)}`,
-      });
-      return;
+      workspaceAliasForRepo = issueMatch.issueAlias;
     }
-  } else {
-    const joplinMatch = parseJoplinPrefix(rawPrompt);
-    if (joplinMatch) {
+
+    if (issueMatch) {
       try {
         await sock.sendMessage(sender, {
-          text: `Reading Joplin note "${joplinMatch.noteQuery}" from notebook "${JOPLIN_NOTEBOOK}" …`,
+          text: `Fetching GitHub issue #${issueMatch.issueNumber} …`,
         });
-        const note = await fetchJoplinNote(joplinMatch.noteQuery);
-        const body = (note.body || '').trim();
-        if (!body) {
+        const fetched = await fetchGhIssuePromptText(issueMatch.issueNumber, {
+          extraInstructions: issueMatch.extraInstructions,
+          workspaceRoot,
+          workspaceAlias: workspaceAliasForRepo,
+        });
+        prompt = fetched.markdown;
+        issueSource = {
+          number: fetched.number,
+          repo: fetched.repo,
+          title: fetched.title,
+        };
+        try {
           await sock.sendMessage(sender, {
-            text: `Joplin note "${note.title}" (${note.id}) has an empty body — nothing to send to Cursor.`,
+            text: `Preparing git in ${workspaceRoot}: checkout latest default branch, pull from origin, create issue branch …`,
+          });
+          const prep = await prepareWorkspaceForGithubIssue(
+            workspaceRoot,
+            issueMatch.issueNumber,
+            issueSource.title
+          );
+          await sock.sendMessage(sender, {
+            text: `Ready on branch \`${prep.branchName}\` (synced from \`${prep.defaultBranch}\`).`,
+          });
+        } catch (prepErr) {
+          await sock.sendMessage(sender, {
+            text: `Git setup for issue #${issueMatch.issueNumber} failed: ${prepErr.message || String(prepErr)}`,
           });
           return;
         }
-        prompt = body;
-        joplinSource = { title: note.title, id: note.id };
       } catch (err) {
         await sock.sendMessage(sender, {
-          text: `Failed to read Joplin note: ${err.message || String(err)}`,
+          text: `Failed to read GitHub issue: ${err.message || String(err)}`,
         });
         return;
       }
+    } else {
+      const joplinMatch = parseJoplinPrefix(rawPrompt);
+      if (joplinMatch) {
+        try {
+          await sock.sendMessage(sender, {
+            text: `Reading Joplin note "${joplinMatch.noteQuery}" from notebook "${JOPLIN_NOTEBOOK}" …`,
+          });
+          const note = await fetchJoplinNote(joplinMatch.noteQuery);
+          const body = (note.body || '').trim();
+          if (!body) {
+            await sock.sendMessage(sender, {
+              text: `Joplin note "${note.title}" (${note.id}) has an empty body — nothing to send to Cursor.`,
+            });
+            return;
+          }
+          prompt = body;
+          joplinSource = { title: note.title, id: note.id };
+        } catch (err) {
+          await sock.sendMessage(sender, {
+            text: `Failed to read Joplin note: ${err.message || String(err)}`,
+          });
+          return;
+        }
+      }
     }
-  }
 
-  const repo = workspaceRoot;
-  const runId = new Date().toISOString().replace(/[:.]/g, '-');
-  const logPath = join(repo, 'logs', 'cursor-agent', `${runId}.log`);
-  const logRel = `logs/cursor-agent/${runId}.log`;
+    const repo = workspaceRoot;
+    const runId = new Date().toISOString().replace(/[:.]/g, '-');
+    const logPath = join(repo, 'logs', 'cursor-agent', `${runId}.log`);
+    const logRel = `logs/cursor-agent/${runId}.log`;
 
-  await setPendingCursorRun({
-    sender,
-    logPath,
-    runId,
-    startedAt: new Date().toISOString(),
-    workspaceRoot: repo,
-  });
-
-  let outcome = 'error';
-  let result;
-  let delivered = false;
-
-  try {
-    const sourceHint = issueSource
-      ? `\nSource: GitHub issue #${issueSource.number} (${issueSource.repo}) — ${issueSource.title || '(no title)'}`
-      : joplinSource
-        ? `\nSource: Joplin note "${joplinSource.title}" (${joplinSource.id})`
-        : '';
-    await sock.sendMessage(sender, {
-      text:
-        `Running Cursor agent in ${repo} …${sourceHint}\n\nLive log (on the Pi):\n${logPath}\n\ntail -f ${logRel}`,
-    });
-
-    result = await runCursorCliAgent(prompt, { runId, workspaceRoot: repo });
-    if (result.timedOut) outcome = 'timeout';
-    else if (result.spawnError) outcome = 'spawn_error';
-    else if (result.ok) outcome = 'success';
-    else outcome = `exit_${result.exitCode}`;
-  } catch (err) {
-    outcome = 'exception';
-    result = {
-      ok: false,
-      exitCode: null,
-      timedOut: false,
-      stdout: '',
-      stderr: String(err?.message || err),
+    await setPendingCursorRun({
+      sender,
       logPath,
       runId,
-    };
-  }
+      startedAt: new Date().toISOString(),
+      workspaceRoot: repo,
+    });
 
-  await logAgentInvocation({
-    agent: 'cursor-cli',
-    model: 'agent',
-    promptTokens: 0,
-    completionTokens: 0,
-    totalTokens: 0,
-    outcome,
-  });
+    let outcome = 'error';
+    let result;
+    let delivered = false;
 
-  try {
-    const body = formatAgentResult(result);
-    const chunks = splitWhatsAppChunks(body);
-    for (const chunk of chunks) {
-      await sock.sendMessage(sender, { text: chunk });
+    try {
+      const sourceHint = issueSource
+        ? `\nSource: GitHub issue #${issueSource.number} (${issueSource.repo}) — ${issueSource.title || '(no title)'}`
+        : joplinSource
+          ? `\nSource: Joplin note "${joplinSource.title}" (${joplinSource.id})`
+          : '';
+      await sock.sendMessage(sender, {
+        text:
+          `Running Cursor agent in ${repo} …${sourceHint}\n\nLive log (on the Pi):\n${logPath}\n\ntail -f ${logRel}`,
+      });
+
+      result = await runCursorCliAgent(prompt, { runId, workspaceRoot: repo });
+      if (result.timedOut) outcome = 'timeout';
+      else if (result.spawnError) outcome = 'spawn_error';
+      else if (result.ok) outcome = 'success';
+      else outcome = `exit_${result.exitCode}`;
+    } catch (err) {
+      outcome = 'exception';
+      result = {
+        ok: false,
+        exitCode: null,
+        timedOut: false,
+        stdout: '',
+        stderr: String(err?.message || err),
+        logPath,
+        runId,
+      };
     }
 
-    const agentRunOk = Boolean(
-      result?.ok && !result?.spawnError && !result?.timedOut
-    );
+    await logAgentInvocation({
+      agent: 'cursor-cli',
+      model: 'agent',
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      outcome,
+    });
+
     try {
-      const post = await maybeCommitReviewEmail({
-        repo,
-        userPrompt: prompt,
-        agentRunOk,
-        issueMode: issueMatch ? { number: issueMatch.issueNumber } : null,
-      });
-      if (post.note) {
-        await sock.sendMessage(sender, { text: post.note });
+      const body = formatAgentResult(result);
+      const chunks = splitWhatsAppChunks(body);
+      for (const chunk of chunks) {
+        await sock.sendMessage(sender, { text: chunk });
       }
-    } catch (postErr) {
-      await sock.sendMessage(sender, {
-        text: `Post-run commit/PR pipeline failed: ${postErr.message || String(postErr)}`,
-      });
-    }
 
-    delivered = true;
-  } catch (sendErr) {
-    try {
-      await sock.sendMessage(sender, {
-        text: `Could not send full Cursor result (${sendErr.message}). Log: ${result?.logPath ?? logPath}`,
-      });
+      const agentRunOk = Boolean(
+        result?.ok && !result?.spawnError && !result?.timedOut
+      );
+      try {
+        const post = await maybeCommitReviewEmail({
+          repo,
+          userPrompt: prompt,
+          agentRunOk,
+          issueMode: issueMatch ? { number: issueMatch.issueNumber } : null,
+        });
+        if (post.note) {
+          await sock.sendMessage(sender, { text: post.note });
+        }
+      } catch (postErr) {
+        await sock.sendMessage(sender, {
+          text: `Post-run commit/PR pipeline failed: ${postErr.message || String(postErr)}`,
+        });
+      }
+
       delivered = true;
-    } catch {
-      /* keep pending file for startup notice */
+    } catch (sendErr) {
+      try {
+        await sock.sendMessage(sender, {
+          text: `Could not send full Cursor result (${sendErr.message}). Log: ${result?.logPath ?? logPath}`,
+        });
+        delivered = true;
+      } catch {
+        /* keep pending file for startup notice */
+      }
+    } finally {
+      if (delivered) await clearPendingCursorRun();
     }
   } finally {
-    if (delivered) await clearPendingCursorRun();
+    releaseAgentBusyLock();
   }
 }

--- a/whatsapp/commands/cursor.js
+++ b/whatsapp/commands/cursor.js
@@ -190,22 +190,6 @@ export default async function cursorCommand(sock, sender, text, msg) {
   }
 
   const ws = parseWorkspacePrefix(afterCursor);
-  let workspaceRoot;
-  try {
-    if (ws.kind === 'alias') {
-      workspaceRoot = await resolveWorkspaceFromAlias(ws.alias);
-    } else if (ws.kind === 'path') {
-      workspaceRoot = await resolveWorkspaceFromUserPath(ws.path);
-    } else {
-      workspaceRoot = await getDefaultWorkspaceRoot();
-    }
-  } catch (e) {
-    await sock.sendMessage(sender, {
-      text: `Cursor workspace: ${e.message || String(e)}`,
-    });
-    return;
-  }
-
   const rawPrompt = ws.rest;
   if (!rawPrompt) {
     await sock.sendMessage(sender, {
@@ -217,11 +201,27 @@ export default async function cursorCommand(sock, sender, text, msg) {
   if (!tryAcquireAgentBusyLock()) {
     await sock.sendMessage(sender, {
       text:
-        'The Cursor agent is already running (issue or freeform). Try again when it finishes.',
+        'The Cursor agent is busy (another run is in progress — issue or freeform). Try again later.',
     });
     return;
   }
   try {
+    let workspaceRoot;
+    try {
+      if (ws.kind === 'alias') {
+        workspaceRoot = await resolveWorkspaceFromAlias(ws.alias);
+      } else if (ws.kind === 'path') {
+        workspaceRoot = await resolveWorkspaceFromUserPath(ws.path);
+      } else {
+        workspaceRoot = await getDefaultWorkspaceRoot();
+      }
+    } catch (e) {
+      await sock.sendMessage(sender, {
+        text: `Cursor workspace: ${e.message || String(e)}`,
+      });
+      return;
+    }
+
     let prompt = rawPrompt;
     let joplinSource = null;
     let issueSource = null;


### PR DESCRIPTION
Fixes #24

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-24-single-agent-busy-lock-reject-manual-cursor-when`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #24

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/24
**State:** OPEN
**Title:** Single-agent busy lock + reject manual cursor when busy

## Body
## Parent

#23

## What to build

Introduce a single shared “agent busy” lock that prevents more than one Cursor agent run at a time across the whole bot process.

When the lock is held, manual WhatsApp `cursor ...` commands must be rejected immediately with a clear “agent is busy, try again later” message (no queuing).

## Acceptance criteria

- [x] If an agent run is in progress, a new manual `cursor ...` command returns a “busy” message and does not start or queue work
- [x] The busy lock is always released (including on exceptions) so the bot can recover without restart
- [x] Behavior is consistent for `cursor issue:n` and non-issue `cursor ...` runs

## Blocked by

None - can start immediately