### PR TITLE
feat: Cron tracer bullet: pick next eligible issue (WhatsappBot … (#25)

### DIFF
--- a/test/cronIssueTracer.test.js
+++ b/test/cronIssueTracer.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { pickNextEligibleIssue } from '../whatsapp/agents/cronIssueTracer.js';
+
+describe('pickNextEligibleIssue', () => {
+  it('returns null when every issue is PRD-prefixed', () => {
+    const r = pickNextEligibleIssue([
+      { number: 23, title: 'PRD: some product doc' },
+      { number: 99, title: 'prd lowercase' },
+    ]);
+    assert.equal(r, null);
+  });
+
+  it('ignores case and leading whitespace for PRD rule', () => {
+    const r = pickNextEligibleIssue([
+      { number: 10, title: '  Prd: x' },
+      { number: 2, title: 'real task' },
+    ]);
+    assert.deepEqual(r, { number: 2, title: 'real task' });
+  });
+
+  it('picks lowest issue number among eligible', () => {
+    const r = pickNextEligibleIssue([
+      { number: 30, title: 'Later' },
+      { number: 5, title: 'First eligible' },
+      { number: 8, title: 'Mid' },
+    ]);
+    assert.deepEqual(r, { number: 5, title: 'First eligible' });
+  });
+
+  it('ignores PRD-prefixed titles that use punctuation after the letters (e.g. PRD-…)', () => {
+    const r = pickNextEligibleIssue([{ number: 1, title: 'PRD-foo' }]);
+    assert.equal(r, null);
+  });
+});

--- a/whatsapp.js
+++ b/whatsapp.js
@@ -39,6 +39,7 @@ import {
   readPendingCursorRun,
   clearPendingCursorRun,
 } from './whatsapp/agents/cursorCliPending.js';
+import { startCronIssueTracer } from './whatsapp/agents/cronIssueTracer.js';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -132,6 +133,18 @@ async function startSock() {
     if (connection === 'open') {
       reconnectAttempt = 0;
       logger.info('✅ WhatsApp connected.');
+      if (myPhone) {
+        startCronIssueTracer({
+          getSocket: () => waSocket,
+          getOwnerJid: () => {
+            const raw = String(myPhone).trim();
+            if (raw.includes('@')) return raw;
+            const d = raw.replace(/\D/g, '');
+            return d ? `${d}@s.whatsapp.net` : null;
+          },
+          logger,
+        });
+      }
       (async () => {
         const pending = await readPendingCursorRun();
         if (pending?.sender && pending?.logPath) {

--- a/whatsapp/agents/cronIssueTracer.js
+++ b/whatsapp/agents/cronIssueTracer.js
@@ -1,0 +1,84 @@
+import { listOpenGithubIssues, resolveIssueRepoSlug } from './ghIssueForCursor.js';
+
+const DEFAULT_MS = 10 * 60 * 1000;
+
+let intervalId = /** @type {ReturnType<typeof setInterval> | null} */ (null);
+let inFlight = false;
+/** @type {number | null} last issue number we already notified the owner about */
+let lastNotifiedNumber = null;
+
+/**
+ * @param {{ number: number, title: string }[]} rows
+ * @returns {{ number: number, title: string } | null} lowest eligible OPEN issue
+ */
+export function pickNextEligibleIssue(rows) {
+  const eligible = rows.filter(
+    (r) => !String(r.title || '').trim().toLowerCase().startsWith('prd')
+  );
+  if (eligible.length === 0) return null;
+  return eligible.reduce((a, b) => (a.number < b.number ? a : b));
+}
+
+/**
+ * 10-minute in-process check: lowest OPEN issue in WhatsappBot, excluding PRD* titles, notify owner.
+ * @param {{
+ *   getSocket: () => import('@whiskeysockets/baileys').WASocket | null | undefined,
+ *   getOwnerJid: () => string | null | undefined,
+ *   logger: { info?: (o: object | string) => void, warn?: (o: object | string) => void },
+ *   intervalMs?: number,
+ * }} opts
+ */
+export function startCronIssueTracer(opts) {
+  const { getSocket, getOwnerJid, logger } = opts;
+  const v = String(process.env.CRON_ISSUE_TRACER_DISABLE || '').toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes') {
+    logger?.info('cron issue tracer: disabled (CRON_ISSUE_TRACER_DISABLE)');
+    return;
+  }
+  if (intervalId) return;
+  const raw = process.env.CRON_ISSUE_TRACER_INTERVAL_MS;
+  const parsed = raw != null && String(raw).trim() !== '' ? parseInt(String(raw), 10) : NaN;
+  const intervalMs = Number.isFinite(opts.intervalMs)
+    ? opts.intervalMs
+    : Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : DEFAULT_MS;
+
+  const tick = async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const sock = getSocket();
+      if (!sock) return;
+      const ownerJid = (getOwnerJid() || '').trim();
+      if (!ownerJid) return;
+      const repo = resolveIssueRepoSlug();
+      const rows = await listOpenGithubIssues({ repo });
+      const next = pickNextEligibleIssue(rows);
+      if (next == null) {
+        lastNotifiedNumber = null;
+        return;
+      }
+      if (next.number === lastNotifiedNumber) return;
+      const text = [
+        'Cron tracer (WhatsappBot): would run the Cursor flow for the next eligible GitHub issue (notify-only; no agent started).',
+        '',
+        `*Repo:* ${repo}`,
+        `*Issue:* #${next.number}`,
+        `*Title:* ${next.title}`,
+      ].join('\n');
+      await sock.sendMessage(ownerJid, { text });
+      lastNotifiedNumber = next.number;
+    } catch (e) {
+      const err = e && typeof e === 'object' && 'message' in e ? (/** @type {Error} */ (e)).message : String(e);
+      logger?.warn({ err }, `cron issue tracer: ${err}`);
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  intervalId = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  void tick();
+}

--- a/whatsapp/agents/ghIssueForCursor.js
+++ b/whatsapp/agents/ghIssueForCursor.js
@@ -208,3 +208,57 @@ export async function fetchGhIssuePromptText(issueNumber, opts = {}) {
     title,
   };
 }
+
+const GH_ISSUE_LIST_MAX = 500;
+
+/**
+ * Open issues in the given repo (GitHub), via `gh issue list`.
+ * @param {{ repo?: string }} [opts]
+ * @returns {Promise<{ number: number, title: string }[]>}
+ */
+export async function listOpenGithubIssues(opts = {}) {
+  const repo = opts.repo?.trim()
+    ? assertValidRepoSlug(opts.repo, 'repo')
+    : resolveIssueRepoSlug();
+  const bin = resolveGhExecutable();
+  const args = [
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'open',
+    '--json',
+    'number,title',
+    '--limit',
+    String(GH_ISSUE_LIST_MAX),
+  ];
+  let stdout;
+  try {
+    ({ stdout } = await execFileAsync(bin, args, {
+      encoding: 'utf8',
+      maxBuffer: 4 * 1024 * 1024,
+      env: { ...process.env, PATH: augmentedPathEnv() },
+    }));
+  } catch (e) {
+    const stderr = typeof e.stderr === 'string' ? e.stderr.trim() : '';
+    const hint =
+      e.code === 'ENOENT'
+        ? `Executable not found (${bin}). Install GitHub CLI or set GH_BIN to the full path to gh.`
+        : stderr || e.message || String(e);
+    throw new Error(hint);
+  }
+  let data;
+  try {
+    data = JSON.parse(stdout);
+  } catch (parseErr) {
+    throw new Error(`gh issue list returned invalid JSON: ${parseErr.message}`);
+  }
+  if (!Array.isArray(data)) return [];
+  return data
+    .map((row) => ({
+      number: typeof row.number === 'number' ? row.number : parseInt(String(row.number), 10),
+      title: String(row.title ?? ''),
+    }))
+    .filter((row) => Number.isFinite(row.number) && row.number > 0);
+}


### PR DESCRIPTION
Fixes #25

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-25-cron-tracer-bullet-pick-next-eligible-issue-what`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #25

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/25
**State:** OPEN
**Title:** Cron tracer bullet: pick next eligible issue (WhatsappBot only) + notify

## Body
## Parent

#23

## What to build

Add a 10-minute in-process scheduler that checks the WhatsappBot GitHub repo for OPEN issues, ignores any whose title starts with `PRD` (case-insensitive), and selects the lowest-numbered eligible issue.

This slice stops at selection + owner notification (no Cursor agent run yet). It proves the polling, filtering, and priority logic end-to-end without mutating repos.

## Acceptance criteria

- [ ] Every 10 minutes the bot can evaluate eligible issues for WhatsappBot
- [ ] Issues whose titles start with `PRD` are ignored
- [ ] The lowest-numbered eligible OPEN issue is selected deterministically
- [ ] The bot sends the owner a WhatsApp message describing what it would run (issue number + title + repo)
- [ ] If there are no eligible issues, it does nothing (no spam)

## Blocked by

- Blocked by #24