### PR TITLE
feat: Cron: auto-run cursor issue pipeline (WhatsappBot) + last-… (#26)

### DIFF
--- a/test/cronIssueTracer.test.js
+++ b/test/cronIssueTracer.test.js
@@ -1,6 +1,13 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { pickNextEligibleIssue } from '../whatsapp/agents/cronIssueTracer.js';
+import {
+  pickNextEligibleIssue,
+  runCronIssueTracerTick,
+} from '../whatsapp/agents/cronIssueTracer.js';
+import {
+  isCursorAgentBusy,
+  releaseAgentBusyLock,
+} from '../whatsapp/agents/cursorAgentBusy.js';
 
 describe('pickNextEligibleIssue', () => {
   it('returns null when every issue is PRD-prefixed', () => {
@@ -31,5 +38,170 @@ describe('pickNextEligibleIssue', () => {
   it('ignores PRD-prefixed titles that use punctuation after the letters (e.g. PRD-…)', () => {
     const r = pickNextEligibleIssue([{ number: 1, title: 'PRD-foo' }]);
     assert.equal(r, null);
+  });
+});
+
+function makeMockSock() {
+  /** @type {{ jid: string, text: string }[]} */
+  const sent = [];
+  return {
+    sent,
+    sendMessage: async (/** @type {string} */ jid, /** @type {{ text?: string }} */ content) => {
+      sent.push({ jid, text: String(content?.text ?? '') });
+    },
+  };
+}
+
+const REPO = 'alexisNorthcoders/WhatsappBot';
+const OWNER = '123@s.whatsapp.net';
+
+describe('runCronIssueTracerTick', () => {
+  beforeEach(() => {
+    if (isCursorAgentBusy()) {
+      releaseAgentBusyLock();
+    }
+  });
+
+  it('releases the agent busy lock when issue fetch / git prep returns null', async () => {
+    const sock = makeMockSock();
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async () => [{ number: 1, title: 'Task' }],
+      resolveIssueRepoSlug: () => REPO,
+      readCronLastStartedIssue: async () => null,
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async () => null,
+      runCursorAgentWithPost: async () => {
+        throw new Error('runCursorAgentWithPost should not run when prep failed');
+      },
+    });
+    assert.equal(isCursorAgentBusy(), false);
+  });
+
+  it('releases the agent busy lock when runCursorAgentWithPost throws', async () => {
+    const sock = makeMockSock();
+    /** @type {unknown[]} */
+    const writes = [];
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async () => [{ number: 2, title: 'Task' }],
+      resolveIssueRepoSlug: () => REPO,
+      readCronLastStartedIssue: async () => null,
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async () => ({
+        prompt: 'p',
+        issueSource: { number: 2, repo: REPO, title: 'Task' },
+      }),
+      runCursorAgentWithPost: async () => {
+        throw 'non-Error rejection';
+      },
+      writeCronLastStartedIssue: async (row) => {
+        writes.push(row);
+      },
+    });
+    assert.equal(isCursorAgentBusy(), false);
+    assert.deepEqual(writes, []);
+    const errMsg = sock.sent.map((m) => m.text).find((t) => t.includes('non-Error'));
+    assert.ok(errMsg, 'owner should be notified of run failure');
+  });
+
+  it('does not call prep when persisted last-started matches the same open eligible issue', async () => {
+    const sock = makeMockSock();
+    let prepCalls = 0;
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async () => [{ number: 10, title: 'Still open' }],
+      resolveIssueRepoSlug: () => REPO,
+      readCronLastStartedIssue: async () => ({
+        repo: REPO,
+        number: 10,
+        savedAt: '2020-01-01T00:00:00.000Z',
+      }),
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async () => {
+        prepCalls++;
+        return { prompt: 'x', issueSource: { number: 10, repo: REPO, title: 'Still open' } };
+      },
+    });
+    assert.equal(prepCalls, 0);
+  });
+
+  it('after a successful agent run, persists last-started and skips the same issue on the next tick', async () => {
+    const sock = makeMockSock();
+    let prepCalls = 0;
+    /** @type {{ repo: string, number: number } | null} */
+    let persisted = null;
+    const readLast = async () =>
+      persisted
+        ? { ...persisted, savedAt: 'saved' }
+        : null;
+    const writeLast = async (/** @type {{ repo: string, number: number }} */ row) => {
+      persisted = { repo: row.repo, number: row.number };
+    };
+
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async () => [{ number: 7, title: 'Work' }],
+      resolveIssueRepoSlug: () => REPO,
+      readCronLastStartedIssue: readLast,
+      writeCronLastStartedIssue: writeLast,
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async () => {
+        prepCalls++;
+        return { prompt: 'p', issueSource: { number: 7, repo: REPO, title: 'Work' } };
+      },
+      runCursorAgentWithPost: async () => {},
+    });
+    assert.equal(prepCalls, 1);
+    assert.deepEqual(persisted, { repo: REPO, number: 7 });
+
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async () => [{ number: 7, title: 'Work' }],
+      resolveIssueRepoSlug: () => REPO,
+      readCronLastStartedIssue: readLast,
+      writeCronLastStartedIssue: writeLast,
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async () => {
+        prepCalls++;
+        return { prompt: 'p', issueSource: { number: 7, repo: REPO, title: 'Work' } };
+      },
+      runCursorAgentWithPost: async () => {
+        throw new Error('should not run again for same issue');
+      },
+    });
+    assert.equal(prepCalls, 1);
+  });
+
+  it('starts work on a different eligible issue when last-started was another number', async () => {
+    const sock = makeMockSock();
+    let prepFor = /** @type {number | null} */ (null);
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async () => [{ number: 20, title: 'New' }],
+      resolveIssueRepoSlug: () => REPO,
+      readCronLastStartedIssue: async () => ({
+        repo: REPO,
+        number: 3,
+        savedAt: 'old',
+      }),
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async (p) => {
+        prepFor = p.issueNumber;
+        return {
+          prompt: 'p',
+          issueSource: { number: p.issueNumber, repo: REPO, title: 'New' },
+        };
+      },
+      runCursorAgentWithPost: async () => {},
+      writeCronLastStartedIssue: async () => {},
+    });
+    assert.equal(prepFor, 20);
   });
 });

--- a/test/cronLastStartedIssue.test.js
+++ b/test/cronLastStartedIssue.test.js
@@ -1,0 +1,48 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  cronLastStartedIssuePath,
+  readCronLastStartedIssue,
+  writeCronLastStartedIssue,
+} from '../whatsapp/agents/cronLastStartedIssue.js';
+
+describe('cronLastStartedIssue persistence', () => {
+  let prevFile;
+  let tmpDir;
+
+  beforeEach(async () => {
+    prevFile = process.env.CRON_LAST_STARTED_ISSUE_FILE;
+    tmpDir = await mkdtemp(join(tmpdir(), 'wabot-cron-'));
+    process.env.CRON_LAST_STARTED_ISSUE_FILE = join(tmpDir, 'state.json');
+  });
+
+  afterEach(async () => {
+    if (prevFile == null) {
+      delete process.env.CRON_LAST_STARTED_ISSUE_FILE;
+    } else {
+      process.env.CRON_LAST_STARTED_ISSUE_FILE = prevFile;
+    }
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('read returns null when missing or invalid', async () => {
+    assert.equal(await readCronLastStartedIssue(), null);
+    const path = cronLastStartedIssuePath();
+    const { writeFile } = await import('fs/promises');
+    await writeFile(path, '{"foo":1}', 'utf8');
+    assert.equal(await readCronLastStartedIssue(), null);
+  });
+
+  it('write then read returns repo, number, savedAt', async () => {
+    await writeCronLastStartedIssue({ repo: 'o/r', number: 26 });
+    const row = await readCronLastStartedIssue();
+    assert.equal(row?.repo, 'o/r');
+    assert.equal(row?.number, 26);
+    assert.ok(String(row?.savedAt || '').length > 0);
+  });
+});

--- a/test/cursorAgentBusy.test.js
+++ b/test/cursorAgentBusy.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  isCursorAgentBusy,
   tryAcquireAgentBusyLock,
   releaseAgentBusyLock,
 } from '../whatsapp/agents/cursorAgentBusy.js';
@@ -8,6 +9,12 @@ import {
 describe('cursorAgentBusy lock', () => {
   beforeEach(() => {
     releaseAgentBusyLock();
+  });
+
+  it('isCursorAgentBusy is false when idle, true when held', () => {
+    assert.equal(isCursorAgentBusy(), false);
+    assert.equal(tryAcquireAgentBusyLock(), true);
+    assert.equal(isCursorAgentBusy(), true);
   });
 
   it('allows one holder and refuses a second', () => {

--- a/test/cursorIssuePipeline.test.js
+++ b/test/cursorIssuePipeline.test.js
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { errorMessageFromUnknown } from '../whatsapp/agents/cursorIssuePipeline.js';
+
+describe('errorMessageFromUnknown', () => {
+  it('uses Error.message', () => {
+    assert.equal(errorMessageFromUnknown(new Error('oops')), 'oops');
+  });
+
+  it('stringifies non-Error throws', () => {
+    assert.equal(errorMessageFromUnknown('boom'), 'boom');
+    assert.equal(errorMessageFromUnknown(null), 'null');
+  });
+
+  it('reads message from plain object', () => {
+    assert.equal(errorMessageFromUnknown({ message: 'from object' }), 'from object');
+  });
+
+  it('falls back when message is empty', () => {
+    assert.ok(
+      String(errorMessageFromUnknown({ message: '' })).length > 0
+    );
+  });
+});

--- a/whatsapp/agents/cronIssueTracer.js
+++ b/whatsapp/agents/cronIssueTracer.js
@@ -15,6 +15,7 @@ import {
 import {
   runIssueFetchAndGitPrep,
   runCursorAgentWithPost,
+  errorMessageFromUnknown,
 } from './cursorIssuePipeline.js';
 
 const DEFAULT_MS = 10 * 60 * 1000;
@@ -42,6 +43,186 @@ function truncateErrorSummary(err, max = 1500) {
   const t = (err || '').replace(/\s+/g, ' ').trim();
   if (t.length <= max) return t;
   return `${t.slice(0, max - 1)}…`;
+}
+
+/**
+ * @typedef {{
+ *   getSocket?: () => import('@whiskeysockets/baileys').WASocket | null | undefined,
+ *   getOwnerJid?: () => string | null | undefined,
+ *   logger?: { info?: (o: object | string) => void, warn?: (o: object | string) => void },
+ *   listOpenGithubIssues?: typeof listOpenGithubIssues,
+ *   resolveIssueRepoSlug?: typeof resolveIssueRepoSlug,
+ *   getDefaultWorkspaceRoot?: typeof getDefaultWorkspaceRoot,
+ *   readCronLastStartedIssue?: typeof readCronLastStartedIssue,
+ *   writeCronLastStartedIssue?: typeof writeCronLastStartedIssue,
+ *   tryAcquireAgentBusyLock?: typeof tryAcquireAgentBusyLock,
+ *   releaseAgentBusyLock?: typeof releaseAgentBusyLock,
+ *   isCursorAgentBusy?: typeof isCursorAgentBusy,
+ *   runIssueFetchAndGitPrep?: typeof runIssueFetchAndGitPrep,
+ *   runCursorAgentWithPost?: typeof runCursorAgentWithPost,
+ * }} CronIssueTracerTickDeps
+ */
+
+/**
+ * One cron evaluation cycle (exported for tests; production uses `startCronIssueTracer`).
+ * Persists last-started only after `runCursorAgentWithPost` completes without throwing, so a crash
+ * or unexpected failure before that point does not suppress retries for the same open issue.
+ *
+ * @param {CronIssueTracerTickDeps} [deps]
+ */
+export async function runCronIssueTracerTick(deps = {}) {
+  const getSocket = deps.getSocket ?? (() => null);
+  const getOwnerJid = deps.getOwnerJid ?? (() => null);
+  const logger = deps.logger;
+  const listIssues = deps.listOpenGithubIssues ?? listOpenGithubIssues;
+  const resolveRepo = deps.resolveIssueRepoSlug ?? resolveIssueRepoSlug;
+  const getWorkspace = deps.getDefaultWorkspaceRoot ?? getDefaultWorkspaceRoot;
+  const readLast = deps.readCronLastStartedIssue ?? readCronLastStartedIssue;
+  const writeLast = deps.writeCronLastStartedIssue ?? writeCronLastStartedIssue;
+  const tryLock = deps.tryAcquireAgentBusyLock ?? tryAcquireAgentBusyLock;
+  const releaseLock = deps.releaseAgentBusyLock ?? releaseAgentBusyLock;
+  const agentBusy = deps.isCursorAgentBusy ?? isCursorAgentBusy;
+  const runPrep = deps.runIssueFetchAndGitPrep ?? runIssueFetchAndGitPrep;
+  const runAgent = deps.runCursorAgentWithPost ?? runCursorAgentWithPost;
+
+  let phase = 'initial checks';
+  /** @type {string | null} */
+  let repoForMsg = null;
+  /** @type {number | null} */
+  let issueNumForMsg = null;
+
+  let acquired = false;
+  try {
+    if (agentBusy()) {
+      return;
+    }
+
+    const sock = getSocket();
+    if (!sock) return;
+    const ownerJid = (getOwnerJid() || '').trim();
+    if (!ownerJid) return;
+
+    phase = 'listing open GitHub issues';
+    const repo = resolveRepo();
+    repoForMsg = repo;
+    const rows = await listIssues({ repo });
+    const next = pickNextEligibleIssue(rows);
+    if (next == null) {
+      return;
+    }
+    issueNumForMsg = next.number;
+
+    phase = 'reading persisted last-started issue';
+    const last = await readLast();
+    if (last && last.repo === repo && last.number === next.number) {
+      return;
+    }
+
+    if (!tryLock()) {
+      return;
+    }
+    acquired = true;
+
+    let workspaceRoot;
+    phase = 'resolving default workspace';
+    try {
+      workspaceRoot = await getWorkspace();
+    } catch (e) {
+      const msg = errorMessageFromUnknown(e);
+      await sock.sendMessage(ownerJid, {
+        text: `Cron (WhatsappBot): could not resolve default workspace (step: ${phase}): ${truncateErrorSummary(msg, 2000)}`,
+      });
+      return;
+    }
+
+    const startText = [
+      'Cron: starting the Cursor *issue* workflow (same as `cursor issue:` from WhatsApp).',
+      '',
+      `*Repo:* ${repo}`,
+      `*Issue:* #${next.number}`,
+      `*Title:* ${next.title}`,
+      '',
+      'Fetching issue and preparing the workspace next…',
+    ].join('\n');
+    phase = 'sending start notification to owner';
+    await sock.sendMessage(ownerJid, { text: startText });
+
+    phase = 'issue fetch / git prep';
+    const prepped = await runPrep({
+      sock,
+      recipientJid: ownerJid,
+      issueNumber: next.number,
+      extraInstructions: '',
+      workspaceRoot,
+      workspaceAlias: null,
+      sendProgressMessages: false,
+    });
+
+    if (!prepped) {
+      await sock.sendMessage(ownerJid, {
+        text: `Cron (WhatsappBot): could not start work on #${next.number} in \`${repo}\` (step: issue fetch or git prep failed; see the message above if one was sent).`,
+      });
+      return;
+    }
+
+    const issueMatch = { issueNumber: next.number, extraInstructions: '' };
+    phase = 'cursor agent run and post-run automation';
+    try {
+      await runAgent({
+        sock,
+        recipientJid: ownerJid,
+        prompt: prepped.prompt,
+        repo: workspaceRoot,
+        issueMatch,
+        issueSource: prepped.issueSource,
+        joplinSource: null,
+        sendProgressMessages: false,
+      });
+      phase = 'persisting last-started issue';
+      await writeLast({ repo, number: next.number });
+    } catch (runErr) {
+      const e = errorMessageFromUnknown(runErr);
+      try {
+        await sock.sendMessage(ownerJid, {
+          text: [
+            `Cron (WhatsappBot): the Cursor run for \`${repo}\` issue #${next.number} failed during: ${phase}.`,
+            '',
+            truncateErrorSummary(e),
+          ].join('\n'),
+        });
+      } catch (sendE) {
+        logger?.warn(
+          { err: errorMessageFromUnknown(sendE) },
+          'cron issue tracer: failed to notify owner of run error'
+        );
+      }
+    }
+  } catch (e) {
+    const err = errorMessageFromUnknown(e);
+    logger?.warn({ err: e }, `cron issue tracer: ${err}`);
+    const sock = getSocket();
+    const ownerJid = (getOwnerJid() || '').trim();
+    if (sock && ownerJid) {
+      try {
+        const issuePart =
+          repoForMsg != null && issueNumForMsg != null
+            ? `issue \`${repoForMsg}#${issueNumForMsg}\` — `
+            : '';
+        await sock.sendMessage(ownerJid, {
+          text: `Cron (WhatsappBot) tick failed while ${issuePart}step *${phase}*: ${truncateErrorSummary(err)}`,
+        });
+      } catch (sendE) {
+        logger?.warn(
+          { err: errorMessageFromUnknown(sendE) },
+          'cron issue tracer: failed to notify tick failure'
+        );
+      }
+    }
+  } finally {
+    if (acquired) {
+      releaseLock();
+    }
+  }
 }
 
 /**
@@ -74,126 +255,9 @@ export function startCronIssueTracer(opts) {
   const tick = async () => {
     if (inFlight) return;
     inFlight = true;
-    let acquired = false;
     try {
-      if (isCursorAgentBusy()) {
-        return;
-      }
-
-      const sock = getSocket();
-      if (!sock) return;
-      const ownerJid = (getOwnerJid() || '').trim();
-      if (!ownerJid) return;
-
-      const repo = resolveIssueRepoSlug();
-      const rows = await listOpenGithubIssues({ repo });
-      const next = pickNextEligibleIssue(rows);
-      if (next == null) {
-        return;
-      }
-
-      const last = await readCronLastStartedIssue();
-      if (last && last.repo === repo && last.number === next.number) {
-        return;
-      }
-
-      if (!tryAcquireAgentBusyLock()) {
-        return;
-      }
-      acquired = true;
-
-      let workspaceRoot;
-      try {
-        workspaceRoot = await getDefaultWorkspaceRoot();
-      } catch (e) {
-        const msg = e && typeof e === 'object' && 'message' in e ? (/** @type {Error} */ (e)).message : String(e);
-        await sock.sendMessage(ownerJid, {
-          text: `Cron (WhatsappBot): could not resolve default workspace: ${truncateErrorSummary(msg, 2000)}`,
-        });
-        return;
-      }
-
-      const startText = [
-        'Cron: starting the Cursor *issue* workflow (same as `cursor issue:` from WhatsApp).',
-        '',
-        `*Repo:* ${repo}`,
-        `*Issue:* #${next.number}`,
-        `*Title:* ${next.title}`,
-        '',
-        'Fetching issue and preparing the workspace next…',
-      ].join('\n');
-      await sock.sendMessage(ownerJid, { text: startText });
-
-      const prepped = await runIssueFetchAndGitPrep({
-        sock,
-        recipientJid: ownerJid,
-        issueNumber: next.number,
-        extraInstructions: '',
-        workspaceRoot,
-        workspaceAlias: null,
-        sendProgressMessages: false,
-      });
-
-      if (!prepped) {
-        await sock.sendMessage(ownerJid, {
-          text: `Cron (WhatsappBot): could not start work on #${next.number} (fetch or git prep failed; see message above).`,
-        });
-        return;
-      }
-
-      const issueMatch = { issueNumber: next.number, extraInstructions: '' };
-      await writeCronLastStartedIssue({ repo, number: next.number });
-      try {
-        await runCursorAgentWithPost({
-          sock,
-          recipientJid: ownerJid,
-          prompt: prepped.prompt,
-          repo: workspaceRoot,
-          issueMatch,
-          issueSource: prepped.issueSource,
-          joplinSource: null,
-          sendProgressMessages: false,
-        });
-      } catch (runErr) {
-        const e = runErr && typeof runErr === 'object' && 'message' in runErr
-          ? (/** @type {Error} */ (runErr)).message
-          : String(runErr);
-        try {
-          await sock.sendMessage(ownerJid, {
-            text: `Cron (WhatsappBot): the Cursor run for #${next.number} hit an error: ${truncateErrorSummary(e)}`,
-          });
-        } catch (sendE) {
-          const se =
-            sendE && typeof sendE === 'object' && 'message' in sendE
-              ? (/** @type {Error} */ (sendE)).message
-              : String(sendE);
-          logger?.warn(
-            { err: se },
-            'cron issue tracer: failed to notify owner of run error'
-          );
-        }
-      }
-    } catch (e) {
-      const err = e && typeof e === 'object' && 'message' in e ? (/** @type {Error} */ (e)).message : String(e);
-      logger?.warn({ err: e }, `cron issue tracer: ${err}`);
-      const sock = getSocket();
-      const ownerJid = (getOwnerJid() || '').trim();
-      if (sock && ownerJid) {
-        try {
-          await sock.sendMessage(ownerJid, {
-            text: `Cron (WhatsappBot) tick failed: ${truncateErrorSummary(err)}`,
-          });
-        } catch (sendE) {
-          const se = sendE && typeof sendE === 'object' && 'message' in sendE
-            ? (/** @type {Error} */ (sendE)).message
-            : String(sendE);
-          logger?.warn({ err: se }, 'cron issue tracer: failed to notify tick failure');
-        }
-      }
+      await runCronIssueTracerTick({ getSocket, getOwnerJid, logger });
     } finally {
-      if (acquired) {
-        releaseAgentBusyLock();
-      }
       inFlight = false;
     }
   };

--- a/whatsapp/agents/cronIssueTracer.js
+++ b/whatsapp/agents/cronIssueTracer.js
@@ -1,11 +1,26 @@
-import { listOpenGithubIssues, resolveIssueRepoSlug } from './ghIssueForCursor.js';
+import {
+  listOpenGithubIssues,
+  resolveIssueRepoSlug,
+} from './ghIssueForCursor.js';
+import { getDefaultWorkspaceRoot } from '../cursorWorkspaces.js';
+import {
+  tryAcquireAgentBusyLock,
+  releaseAgentBusyLock,
+  isCursorAgentBusy,
+} from './cursorAgentBusy.js';
+import {
+  readCronLastStartedIssue,
+  writeCronLastStartedIssue,
+} from './cronLastStartedIssue.js';
+import {
+  runIssueFetchAndGitPrep,
+  runCursorAgentWithPost,
+} from './cursorIssuePipeline.js';
 
 const DEFAULT_MS = 10 * 60 * 1000;
 
 let intervalId = /** @type {ReturnType<typeof setInterval> | null} */ (null);
 let inFlight = false;
-/** @type {number | null} last issue number we already notified the owner about */
-let lastNotifiedNumber = null;
 
 /**
  * @param {{ number: number, title: string }[]} rows
@@ -20,7 +35,19 @@ export function pickNextEligibleIssue(rows) {
 }
 
 /**
- * 10-minute in-process check: lowest OPEN issue in WhatsappBot, excluding PRD* titles, notify owner.
+ * @param {string} err
+ * @param {number} [max]
+ */
+function truncateErrorSummary(err, max = 1500) {
+  const t = (err || '').replace(/\s+/g, ' ').trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, max - 1)}…`;
+}
+
+/**
+ * Interval job: if an eligible WhatsappBot issue exists and the Cursor agent is free, run the
+ * same pipeline as a manual `cursor issue:<n>` (fetch, git prep, agent, post-run automation).
+ * Persists last-started (repo + issue) so the same open issue is not re-dispatched every tick.
  * @param {{
  *   getSocket: () => import('@whiskeysockets/baileys').WASocket | null | undefined,
  *   getOwnerJid: () => string | null | undefined,
@@ -47,32 +74,126 @@ export function startCronIssueTracer(opts) {
   const tick = async () => {
     if (inFlight) return;
     inFlight = true;
+    let acquired = false;
     try {
+      if (isCursorAgentBusy()) {
+        return;
+      }
+
       const sock = getSocket();
       if (!sock) return;
       const ownerJid = (getOwnerJid() || '').trim();
       if (!ownerJid) return;
+
       const repo = resolveIssueRepoSlug();
       const rows = await listOpenGithubIssues({ repo });
       const next = pickNextEligibleIssue(rows);
       if (next == null) {
-        lastNotifiedNumber = null;
         return;
       }
-      if (next.number === lastNotifiedNumber) return;
-      const text = [
-        'Cron tracer (WhatsappBot): would run the Cursor flow for the next eligible GitHub issue (notify-only; no agent started).',
+
+      const last = await readCronLastStartedIssue();
+      if (last && last.repo === repo && last.number === next.number) {
+        return;
+      }
+
+      if (!tryAcquireAgentBusyLock()) {
+        return;
+      }
+      acquired = true;
+
+      let workspaceRoot;
+      try {
+        workspaceRoot = await getDefaultWorkspaceRoot();
+      } catch (e) {
+        const msg = e && typeof e === 'object' && 'message' in e ? (/** @type {Error} */ (e)).message : String(e);
+        await sock.sendMessage(ownerJid, {
+          text: `Cron (WhatsappBot): could not resolve default workspace: ${truncateErrorSummary(msg, 2000)}`,
+        });
+        return;
+      }
+
+      const startText = [
+        'Cron: starting the Cursor *issue* workflow (same as `cursor issue:` from WhatsApp).',
         '',
         `*Repo:* ${repo}`,
         `*Issue:* #${next.number}`,
         `*Title:* ${next.title}`,
+        '',
+        'Fetching issue and preparing the workspace next…',
       ].join('\n');
-      await sock.sendMessage(ownerJid, { text });
-      lastNotifiedNumber = next.number;
+      await sock.sendMessage(ownerJid, { text: startText });
+
+      const prepped = await runIssueFetchAndGitPrep({
+        sock,
+        recipientJid: ownerJid,
+        issueNumber: next.number,
+        extraInstructions: '',
+        workspaceRoot,
+        workspaceAlias: null,
+        sendProgressMessages: false,
+      });
+
+      if (!prepped) {
+        await sock.sendMessage(ownerJid, {
+          text: `Cron (WhatsappBot): could not start work on #${next.number} (fetch or git prep failed; see message above).`,
+        });
+        return;
+      }
+
+      const issueMatch = { issueNumber: next.number, extraInstructions: '' };
+      await writeCronLastStartedIssue({ repo, number: next.number });
+      try {
+        await runCursorAgentWithPost({
+          sock,
+          recipientJid: ownerJid,
+          prompt: prepped.prompt,
+          repo: workspaceRoot,
+          issueMatch,
+          issueSource: prepped.issueSource,
+          joplinSource: null,
+          sendProgressMessages: false,
+        });
+      } catch (runErr) {
+        const e = runErr && typeof runErr === 'object' && 'message' in runErr
+          ? (/** @type {Error} */ (runErr)).message
+          : String(runErr);
+        try {
+          await sock.sendMessage(ownerJid, {
+            text: `Cron (WhatsappBot): the Cursor run for #${next.number} hit an error: ${truncateErrorSummary(e)}`,
+          });
+        } catch (sendE) {
+          const se =
+            sendE && typeof sendE === 'object' && 'message' in sendE
+              ? (/** @type {Error} */ (sendE)).message
+              : String(sendE);
+          logger?.warn(
+            { err: se },
+            'cron issue tracer: failed to notify owner of run error'
+          );
+        }
+      }
     } catch (e) {
       const err = e && typeof e === 'object' && 'message' in e ? (/** @type {Error} */ (e)).message : String(e);
-      logger?.warn({ err }, `cron issue tracer: ${err}`);
+      logger?.warn({ err: e }, `cron issue tracer: ${err}`);
+      const sock = getSocket();
+      const ownerJid = (getOwnerJid() || '').trim();
+      if (sock && ownerJid) {
+        try {
+          await sock.sendMessage(ownerJid, {
+            text: `Cron (WhatsappBot) tick failed: ${truncateErrorSummary(err)}`,
+          });
+        } catch (sendE) {
+          const se = sendE && typeof sendE === 'object' && 'message' in sendE
+            ? (/** @type {Error} */ (sendE)).message
+            : String(sendE);
+          logger?.warn({ err: se }, 'cron issue tracer: failed to notify tick failure');
+        }
+      }
     } finally {
+      if (acquired) {
+        releaseAgentBusyLock();
+      }
       inFlight = false;
     }
   };

--- a/whatsapp/agents/cronLastStartedIssue.js
+++ b/whatsapp/agents/cronLastStartedIssue.js
@@ -1,0 +1,59 @@
+import { promises as fs } from 'fs';
+import { dirname, join } from 'path';
+import { getCursorCliRepoRoot } from './cursorCliAgent.js';
+
+const FILE = 'cron-last-started-issue.json';
+
+/**
+ * @returns {string} absolute path to the persisted state file
+ */
+export function cronLastStartedIssuePath() {
+  const fromEnv = process.env.CRON_LAST_STARTED_ISSUE_FILE?.trim();
+  if (fromEnv) return fromEnv;
+  return join(
+    getCursorCliRepoRoot(),
+    'logs',
+    'cursor-agent',
+    FILE
+  );
+}
+
+/**
+ * @returns {Promise<{ repo: string, number: number, savedAt: string } | null>}
+ */
+export async function readCronLastStartedIssue() {
+  const path = cronLastStartedIssuePath();
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    const data = JSON.parse(raw);
+    if (
+      !data ||
+      typeof data.repo !== 'string' ||
+      !Number.isFinite(data.number) ||
+      data.number < 1
+    ) {
+      return null;
+    }
+    return {
+      repo: data.repo,
+      number: data.number,
+      savedAt: typeof data.savedAt === 'string' ? data.savedAt : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {{ repo: string, number: number }} row
+ */
+export async function writeCronLastStartedIssue(row) {
+  const path = cronLastStartedIssuePath();
+  await fs.mkdir(dirname(path), { recursive: true });
+  const payload = {
+    repo: row.repo,
+    number: row.number,
+    savedAt: new Date().toISOString(),
+  };
+  await fs.writeFile(path, JSON.stringify(payload, null, 2), 'utf8');
+}

--- a/whatsapp/agents/cursorAgentBusy.js
+++ b/whatsapp/agents/cursorAgentBusy.js
@@ -3,6 +3,13 @@
 let busy = false;
 
 /**
+ * @returns {boolean} whether a Cursor issue/freeform run is in progress
+ */
+export function isCursorAgentBusy() {
+  return busy;
+}
+
+/**
  * @returns {boolean} true if this call holds the lock; false if another run is in progress
  */
 export function tryAcquireAgentBusyLock() {

--- a/whatsapp/agents/cursorIssuePipeline.js
+++ b/whatsapp/agents/cursorIssuePipeline.js
@@ -8,6 +8,26 @@ import { fetchGhIssuePromptText } from './ghIssueForCursor.js';
 const WA_TEXT_MAX = 4096;
 
 /**
+ * @param {unknown} err
+ * @returns {string}
+ */
+export function errorMessageFromUnknown(err) {
+  if (err instanceof Error) {
+    const m = err.message;
+    return typeof m === 'string' && m.trim() !== '' ? m : err.name || 'Error';
+  }
+  if (err && typeof err === 'object' && 'message' in err) {
+    const m = /** @type {{ message?: unknown }} */ (err).message;
+    if (typeof m === 'string' && m.trim() !== '') return m;
+  }
+  try {
+    return String(err);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+/**
  * @param {string} text
  * @param {number} [maxLen]
  * @returns {string[]}
@@ -124,7 +144,7 @@ export async function runIssueFetchAndGitPrep(p) {
       }
     } catch (prepErr) {
       await sock.sendMessage(recipientJid, {
-        text: `Git setup for issue #${issueNumber} failed: ${prepErr.message || String(prepErr)}`,
+        text: `Git setup for issue #${issueNumber} failed: ${errorMessageFromUnknown(prepErr)}`,
       });
       return null;
     }
@@ -132,7 +152,7 @@ export async function runIssueFetchAndGitPrep(p) {
     return { prompt, issueSource };
   } catch (err) {
     await sock.sendMessage(recipientJid, {
-      text: `Failed to read GitHub issue: ${err.message || String(err)}`,
+      text: `Failed to read GitHub issue: ${errorMessageFromUnknown(err)}`,
     });
     return null;
   }
@@ -205,7 +225,7 @@ export async function runCursorAgentWithPost(p) {
       exitCode: null,
       timedOut: false,
       stdout: '',
-      stderr: String(err?.message || err),
+      stderr: errorMessageFromUnknown(err),
       logPath,
       runId,
     };
@@ -242,7 +262,7 @@ export async function runCursorAgentWithPost(p) {
       }
     } catch (postErr) {
       await sock.sendMessage(recipientJid, {
-        text: `Post-run commit/PR pipeline failed: ${postErr.message || String(postErr)}`,
+        text: `Post-run commit/PR pipeline failed: ${errorMessageFromUnknown(postErr)}`,
       });
     }
 
@@ -250,7 +270,7 @@ export async function runCursorAgentWithPost(p) {
   } catch (sendErr) {
     try {
       await sock.sendMessage(recipientJid, {
-        text: `Could not send full Cursor result (${sendErr.message}). Log: ${result?.logPath ?? logPath}`,
+        text: `Could not send full Cursor result (${errorMessageFromUnknown(sendErr)}). Log: ${result?.logPath ?? logPath}`,
       });
       delivered = true;
     } catch {

--- a/whatsapp/agents/cursorIssuePipeline.js
+++ b/whatsapp/agents/cursorIssuePipeline.js
@@ -1,0 +1,262 @@
+import { join } from 'path';
+import { runCursorCliAgent } from './cursorCliAgent.js';
+import { setPendingCursorRun, clearPendingCursorRun } from './cursorCliPending.js';
+import { logAgentInvocation } from './agentUsageLog.js';
+import { maybeCommitReviewEmail, prepareWorkspaceForGithubIssue } from './cursorPostRun.js';
+import { fetchGhIssuePromptText } from './ghIssueForCursor.js';
+
+const WA_TEXT_MAX = 4096;
+
+/**
+ * @param {string} text
+ * @param {number} [maxLen]
+ * @returns {string[]}
+ */
+function splitWhatsAppChunks(text, maxLen = WA_TEXT_MAX) {
+  if (!text || text.length <= maxLen) return text ? [text] : ['(no output)'];
+  const parts = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLen) {
+      parts.push(remaining);
+      break;
+    }
+    let chunk = remaining.slice(0, maxLen);
+    const nl = chunk.lastIndexOf('\n');
+    if (nl > Math.floor(maxLen * 0.5)) chunk = chunk.slice(0, nl + 1);
+    parts.push(chunk.replace(/\s+$/, ''));
+    remaining = remaining.slice(chunk.length);
+  }
+  return parts;
+}
+
+/** @param {Record<string, unknown> & { logPath?: string, spawnError?: string, timedOut?: boolean, exitCode?: number|null, signal?: string|null, ok?: boolean, stdout?: string, stderr?: string }} result */
+function formatAgentResult(result) {
+  const lines = [];
+  if (result.logPath) {
+    lines.push(`Log file: ${result.logPath}`);
+    lines.push('');
+  }
+  if (result.spawnError) {
+    lines.push(`Spawn error: ${result.spawnError}`);
+    return lines.join('\n');
+  }
+  if (result.timedOut) {
+    lines.push(
+      `Timed out (exit ${result.exitCode ?? 'n/a'}, signal ${result.signal ?? 'n/a'}).`
+    );
+  } else {
+    lines.push(`Exit code: ${result.exitCode ?? 'n/a'}`);
+  }
+  if (result.stdout?.trim()) {
+    lines.push('--- stdout ---');
+    lines.push(result.stdout.trimEnd());
+  }
+  if (result.stderr?.trim()) {
+    lines.push('--- stderr ---');
+    lines.push(result.stderr.trimEnd());
+  }
+  if (lines.length === 1 && lines[0].startsWith('Exit code:')) {
+    lines.push('(no stdout/stderr captured)');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Fetches the GitHub issue, prepares the workspace, and returns the agent prompt. Sends WhatsApp
+ * error messages and returns `null` on failure.
+ *
+ * @param {{
+ *   sock: import('@whiskeysockets/baileys').WASocket,
+ *   recipientJid: string,
+ *   issueNumber: number,
+ *   extraInstructions: string,
+ *   workspaceRoot: string,
+ *   workspaceAlias: string | null,
+ *   sendProgressMessages?: boolean,
+ * }} p
+ * @returns {Promise<{ prompt: string, issueSource: { number: number, repo: string, title: string } } | null>}
+ */
+export async function runIssueFetchAndGitPrep(p) {
+  const {
+    sock,
+    recipientJid,
+    issueNumber,
+    extraInstructions,
+    workspaceRoot,
+    workspaceAlias,
+    sendProgressMessages = true,
+  } = p;
+
+  try {
+    if (sendProgressMessages) {
+      await sock.sendMessage(recipientJid, {
+        text: `Fetching GitHub issue #${issueNumber} …`,
+      });
+    }
+    const fetched = await fetchGhIssuePromptText(issueNumber, {
+      extraInstructions,
+      workspaceRoot,
+      workspaceAlias,
+    });
+    const prompt = fetched.markdown;
+    const issueSource = {
+      number: fetched.number,
+      repo: fetched.repo,
+      title: fetched.title,
+    };
+
+    try {
+      if (sendProgressMessages) {
+        await sock.sendMessage(recipientJid, {
+          text: `Preparing git in ${workspaceRoot}: checkout latest default branch, pull from origin, create issue branch …`,
+        });
+      }
+      const prep = await prepareWorkspaceForGithubIssue(
+        workspaceRoot,
+        issueNumber,
+        issueSource.title
+      );
+      if (sendProgressMessages) {
+        await sock.sendMessage(recipientJid, {
+          text: `Ready on branch \`${prep.branchName}\` (synced from \`${prep.defaultBranch}\`).`,
+        });
+      }
+    } catch (prepErr) {
+      await sock.sendMessage(recipientJid, {
+        text: `Git setup for issue #${issueNumber} failed: ${prepErr.message || String(prepErr)}`,
+      });
+      return null;
+    }
+
+    return { prompt, issueSource };
+  } catch (err) {
+    await sock.sendMessage(recipientJid, {
+      text: `Failed to read GitHub issue: ${err.message || String(err)}`,
+    });
+    return null;
+  }
+}
+
+/**
+ * Runs the Cursor agent and post-run PR/review steps (shared by manual and cron issue flows).
+ *
+ * @param {{
+ *   sock: import('@whiskeysockets/baileys').WASocket,
+ *   recipientJid: string,
+ *   prompt: string,
+ *   repo: string,
+ *   issueMatch: { issueNumber: number } | null,
+ *   issueSource: { number: number, repo: string, title: string } | null,
+ *   joplinSource: { title: string, id: string } | null,
+ *   sendProgressMessages?: boolean,
+ * }} p
+ */
+export async function runCursorAgentWithPost(p) {
+  const {
+    sock,
+    recipientJid,
+    prompt,
+    repo,
+    issueMatch,
+    issueSource,
+    joplinSource,
+    sendProgressMessages = true,
+  } = p;
+
+  const runId = new Date().toISOString().replace(/[:.]/g, '-');
+  const logPath = join(repo, 'logs', 'cursor-agent', `${runId}.log`);
+  const logRel = `logs/cursor-agent/${runId}.log`;
+
+  await setPendingCursorRun({
+    sender: recipientJid,
+    logPath,
+    runId,
+    startedAt: new Date().toISOString(),
+    workspaceRoot: repo,
+  });
+
+  let outcome = 'error';
+  let result;
+  let delivered = false;
+
+  try {
+    const sourceHint = issueSource
+      ? `\nSource: GitHub issue #${issueSource.number} (${issueSource.repo}) — ${issueSource.title || '(no title)'}`
+      : joplinSource
+        ? `\nSource: Joplin note "${joplinSource.title}" (${joplinSource.id})`
+        : '';
+    if (sendProgressMessages) {
+      await sock.sendMessage(recipientJid, {
+        text:
+          `Running Cursor agent in ${repo} …${sourceHint}\n\nLive log (on the Pi):\n${logPath}\n\ntail -f ${logRel}`,
+      });
+    }
+
+    result = await runCursorCliAgent(prompt, { runId, workspaceRoot: repo });
+    if (result.timedOut) outcome = 'timeout';
+    else if (result.spawnError) outcome = 'spawn_error';
+    else if (result.ok) outcome = 'success';
+    else outcome = `exit_${result.exitCode}`;
+  } catch (err) {
+    outcome = 'exception';
+    result = {
+      ok: false,
+      exitCode: null,
+      timedOut: false,
+      stdout: '',
+      stderr: String(err?.message || err),
+      logPath,
+      runId,
+    };
+  }
+
+  await logAgentInvocation({
+    agent: 'cursor-cli',
+    model: 'agent',
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    outcome,
+  });
+
+  try {
+    const body = formatAgentResult(result);
+    const chunks = splitWhatsAppChunks(body);
+    for (const chunk of chunks) {
+      await sock.sendMessage(recipientJid, { text: chunk });
+    }
+
+    const agentRunOk = Boolean(
+      result?.ok && !result?.spawnError && !result?.timedOut
+    );
+    try {
+      const post = await maybeCommitReviewEmail({
+        repo,
+        userPrompt: prompt,
+        agentRunOk,
+        issueMode: issueMatch ? { number: issueMatch.issueNumber } : null,
+      });
+      if (post.note) {
+        await sock.sendMessage(recipientJid, { text: post.note });
+      }
+    } catch (postErr) {
+      await sock.sendMessage(recipientJid, {
+        text: `Post-run commit/PR pipeline failed: ${postErr.message || String(postErr)}`,
+      });
+    }
+
+    delivered = true;
+  } catch (sendErr) {
+    try {
+      await sock.sendMessage(recipientJid, {
+        text: `Could not send full Cursor result (${sendErr.message}). Log: ${result?.logPath ?? logPath}`,
+      });
+      delivered = true;
+    } catch {
+      /* keep pending file for startup notice */
+    }
+  } finally {
+    if (delivered) await clearPendingCursorRun();
+  }
+}

--- a/whatsapp/commands/cursor.js
+++ b/whatsapp/commands/cursor.js
@@ -1,23 +1,11 @@
 import dotenv from 'dotenv';
-import { join } from 'path';
-import { runCursorCliAgent } from '../agents/cursorCliAgent.js';
+import { getDefaultWorkspaceRoot, resolveWorkspaceFromAlias, resolveWorkspaceFromUserPath } from '../cursorWorkspaces.js';
 import {
-  setPendingCursorRun,
-  clearPendingCursorRun,
-} from '../agents/cursorCliPending.js';
-import {
-  getDefaultWorkspaceRoot,
-  resolveWorkspaceFromAlias,
-  resolveWorkspaceFromUserPath,
-} from '../cursorWorkspaces.js';
-import { logAgentInvocation } from '../agents/agentUsageLog.js';
-import {
-  maybeCommitReviewEmail,
-  prepareWorkspaceForGithubIssue,
-} from '../agents/cursorPostRun.js';
+  runIssueFetchAndGitPrep,
+  runCursorAgentWithPost,
+} from '../agents/cursorIssuePipeline.js';
 import joplinAPI, { WHATSAPP_BOT_NOTEBOOK } from '../../joplin/index.js';
 import { actorJid, isAllowedActor, lidExtraJidsHint } from '../whatsAppActorAllowlist.js';
-import { fetchGhIssuePromptText } from '../agents/ghIssueForCursor.js';
 import {
   tryAcquireAgentBusyLock,
   releaseAgentBusyLock,
@@ -25,7 +13,6 @@ import {
 
 dotenv.config();
 
-const WA_TEXT_MAX = 4096;
 const JOPLIN_NOTEBOOK =
   process.env.JOPLIN_AGENT_NOTEBOOK?.trim() || WHATSAPP_BOT_NOTEBOOK;
 
@@ -123,53 +110,6 @@ async function fetchJoplinNote(noteQuery) {
   return joplinAPI.getNoteInNotebook(best.id, JOPLIN_NOTEBOOK);
 }
 
-function splitWhatsAppChunks(text, maxLen = WA_TEXT_MAX) {
-  if (!text || text.length <= maxLen) return text ? [text] : ['(no output)'];
-  const parts = [];
-  let remaining = text;
-  while (remaining.length > 0) {
-    if (remaining.length <= maxLen) {
-      parts.push(remaining);
-      break;
-    }
-    let chunk = remaining.slice(0, maxLen);
-    const nl = chunk.lastIndexOf('\n');
-    if (nl > Math.floor(maxLen * 0.5)) chunk = chunk.slice(0, nl + 1);
-    parts.push(chunk.replace(/\s+$/, ''));
-    remaining = remaining.slice(chunk.length);
-  }
-  return parts;
-}
-
-function formatAgentResult(result) {
-  const lines = [];
-  if (result.logPath) {
-    lines.push(`Log file: ${result.logPath}`);
-    lines.push('');
-  }
-  if (result.spawnError) {
-    lines.push(`Spawn error: ${result.spawnError}`);
-    return lines.join('\n');
-  }
-  if (result.timedOut) {
-    lines.push(`Timed out (exit ${result.exitCode ?? 'n/a'}, signal ${result.signal ?? 'n/a'}).`);
-  } else {
-    lines.push(`Exit code: ${result.exitCode ?? 'n/a'}`);
-  }
-  if (result.stdout?.trim()) {
-    lines.push('--- stdout ---');
-    lines.push(result.stdout.trimEnd());
-  }
-  if (result.stderr?.trim()) {
-    lines.push('--- stderr ---');
-    lines.push(result.stderr.trimEnd());
-  }
-  if (lines.length === 1 && lines[0].startsWith('Exit code:')) {
-    lines.push('(no stdout/stderr captured)');
-  }
-  return lines.join('\n');
-}
-
 export default async function cursorCommand(sock, sender, text, msg) {
   const actor = actorJid(msg, sender);
   if (!isAllowedActor(actor)) {
@@ -242,45 +182,18 @@ export default async function cursorCommand(sock, sender, text, msg) {
     }
 
     if (issueMatch) {
-      try {
-        await sock.sendMessage(sender, {
-          text: `Fetching GitHub issue #${issueMatch.issueNumber} …`,
-        });
-        const fetched = await fetchGhIssuePromptText(issueMatch.issueNumber, {
-          extraInstructions: issueMatch.extraInstructions,
-          workspaceRoot,
-          workspaceAlias: workspaceAliasForRepo,
-        });
-        prompt = fetched.markdown;
-        issueSource = {
-          number: fetched.number,
-          repo: fetched.repo,
-          title: fetched.title,
-        };
-        try {
-          await sock.sendMessage(sender, {
-            text: `Preparing git in ${workspaceRoot}: checkout latest default branch, pull from origin, create issue branch …`,
-          });
-          const prep = await prepareWorkspaceForGithubIssue(
-            workspaceRoot,
-            issueMatch.issueNumber,
-            issueSource.title
-          );
-          await sock.sendMessage(sender, {
-            text: `Ready on branch \`${prep.branchName}\` (synced from \`${prep.defaultBranch}\`).`,
-          });
-        } catch (prepErr) {
-          await sock.sendMessage(sender, {
-            text: `Git setup for issue #${issueMatch.issueNumber} failed: ${prepErr.message || String(prepErr)}`,
-          });
-          return;
-        }
-      } catch (err) {
-        await sock.sendMessage(sender, {
-          text: `Failed to read GitHub issue: ${err.message || String(err)}`,
-        });
-        return;
-      }
+      const prepped = await runIssueFetchAndGitPrep({
+        sock,
+        recipientJid: sender,
+        issueNumber: issueMatch.issueNumber,
+        extraInstructions: issueMatch.extraInstructions,
+        workspaceRoot,
+        workspaceAlias: workspaceAliasForRepo,
+        sendProgressMessages: true,
+      });
+      if (!prepped) return;
+      prompt = prepped.prompt;
+      issueSource = prepped.issueSource;
     } else {
       const joplinMatch = parseJoplinPrefix(rawPrompt);
       if (joplinMatch) {
@@ -307,100 +220,16 @@ export default async function cursorCommand(sock, sender, text, msg) {
       }
     }
 
-    const repo = workspaceRoot;
-    const runId = new Date().toISOString().replace(/[:.]/g, '-');
-    const logPath = join(repo, 'logs', 'cursor-agent', `${runId}.log`);
-    const logRel = `logs/cursor-agent/${runId}.log`;
-
-    await setPendingCursorRun({
-      sender,
-      logPath,
-      runId,
-      startedAt: new Date().toISOString(),
-      workspaceRoot: repo,
+    await runCursorAgentWithPost({
+      sock,
+      recipientJid: sender,
+      prompt,
+      repo: workspaceRoot,
+      issueMatch,
+      issueSource,
+      joplinSource,
+      sendProgressMessages: true,
     });
-
-    let outcome = 'error';
-    let result;
-    let delivered = false;
-
-    try {
-      const sourceHint = issueSource
-        ? `\nSource: GitHub issue #${issueSource.number} (${issueSource.repo}) — ${issueSource.title || '(no title)'}`
-        : joplinSource
-          ? `\nSource: Joplin note "${joplinSource.title}" (${joplinSource.id})`
-          : '';
-      await sock.sendMessage(sender, {
-        text:
-          `Running Cursor agent in ${repo} …${sourceHint}\n\nLive log (on the Pi):\n${logPath}\n\ntail -f ${logRel}`,
-      });
-
-      result = await runCursorCliAgent(prompt, { runId, workspaceRoot: repo });
-      if (result.timedOut) outcome = 'timeout';
-      else if (result.spawnError) outcome = 'spawn_error';
-      else if (result.ok) outcome = 'success';
-      else outcome = `exit_${result.exitCode}`;
-    } catch (err) {
-      outcome = 'exception';
-      result = {
-        ok: false,
-        exitCode: null,
-        timedOut: false,
-        stdout: '',
-        stderr: String(err?.message || err),
-        logPath,
-        runId,
-      };
-    }
-
-    await logAgentInvocation({
-      agent: 'cursor-cli',
-      model: 'agent',
-      promptTokens: 0,
-      completionTokens: 0,
-      totalTokens: 0,
-      outcome,
-    });
-
-    try {
-      const body = formatAgentResult(result);
-      const chunks = splitWhatsAppChunks(body);
-      for (const chunk of chunks) {
-        await sock.sendMessage(sender, { text: chunk });
-      }
-
-      const agentRunOk = Boolean(
-        result?.ok && !result?.spawnError && !result?.timedOut
-      );
-      try {
-        const post = await maybeCommitReviewEmail({
-          repo,
-          userPrompt: prompt,
-          agentRunOk,
-          issueMode: issueMatch ? { number: issueMatch.issueNumber } : null,
-        });
-        if (post.note) {
-          await sock.sendMessage(sender, { text: post.note });
-        }
-      } catch (postErr) {
-        await sock.sendMessage(sender, {
-          text: `Post-run commit/PR pipeline failed: ${postErr.message || String(postErr)}`,
-        });
-      }
-
-      delivered = true;
-    } catch (sendErr) {
-      try {
-        await sock.sendMessage(sender, {
-          text: `Could not send full Cursor result (${sendErr.message}). Log: ${result?.logPath ?? logPath}`,
-        });
-        delivered = true;
-      } catch {
-        /* keep pending file for startup notice */
-      }
-    } finally {
-      if (delivered) await clearPendingCursorRun();
-    }
   } finally {
     releaseAgentBusyLock();
   }


### PR DESCRIPTION
Fixes #26

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-26-cron-auto-run-cursor-issue-pipeline-whatsappbot-`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #26

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/26
**State:** OPEN
**Title:** Cron: auto-run cursor issue pipeline (WhatsappBot) + last-started persistence

## Body
## Parent

#23

## What to build

Extend the cron runner so that when it selects an eligible issue for WhatsappBot, it launches the same end-to-end workflow as a manual WhatsApp `cursor issue:n` run (issue prompt fetch, workspace git prep, headless agent run, and existing post-run PR/review automation).

Add persisted state so the cron does not automatically start the same still-open issue again on later ticks (or after restart) once it has started it.

## Acceptance criteria

- [ ] If the agent is busy, cron does not start new work
- [ ] When an eligible issue is found, cron starts the Cursor agent workflow equivalent to `cursor issue:n`
- [ ] Owner receives a WhatsApp message when cron starts work (repo + issue number + title)
- [ ] Owner receives a WhatsApp message on failure with a useful error summary
- [ ] Cron persists “last started issue” so it will not repeatedly start the same open issue every 10 minutes
- [ ] On restart, the persisted “last started issue” still prevents immediate re-start of the same open issue

## Blocked by

- Blocked by #24
- Blocked by #25