### PR TITLE
feat: Cron: add Platformer repo support (secondary priority) (#27)

### DIFF
--- a/test/cronIssueTracer.test.js
+++ b/test/cronIssueTracer.test.js
@@ -2,6 +2,7 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   pickNextEligibleIssue,
+  pickNextRunnableIssueForRepo,
   runCronIssueTracerTick,
 } from '../whatsapp/agents/cronIssueTracer.js';
 import {
@@ -38,6 +39,20 @@ describe('pickNextEligibleIssue', () => {
   it('ignores PRD-prefixed titles that use punctuation after the letters (e.g. PRD-…)', () => {
     const r = pickNextEligibleIssue([{ number: 1, title: 'PRD-foo' }]);
     assert.equal(r, null);
+  });
+});
+
+describe('pickNextRunnableIssueForRepo', () => {
+  it('returns null when the only eligible issue matches last-started for that repo', () => {
+    const last = new Map([[REPO, 3]]);
+    const r = pickNextRunnableIssueForRepo([{ number: 3, title: 'Open' }], REPO, last);
+    assert.equal(r, null);
+  });
+
+  it('returns the eligible issue when last-started is a different number', () => {
+    const last = new Map([[REPO, 2]]);
+    const r = pickNextRunnableIssueForRepo([{ number: 5, title: 'Open' }], REPO, last);
+    assert.deepEqual(r, { number: 5, title: 'Open' });
   });
 });
 
@@ -114,10 +129,18 @@ describe('runCronIssueTracerTick', () => {
     await runCronIssueTracerTick({
       getSocket: () => sock,
       getOwnerJid: () => OWNER,
-      listOpenGithubIssues: async () => [{ number: 10, title: 'Still open' }],
+      listOpenGithubIssues: async ({ repo }) => {
+        if (repo === REPO) return [{ number: 10, title: 'Still open' }];
+        if (repo === REPO_P) return [];
+        throw new Error(`unexpected list ${repo}`);
+      },
       resolveIssueRepoSlug: () => REPO,
       readCronPerRepoLastStarted: async () => new Map([[REPO, 10]]),
-      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => {
+        throw new Error('getDefaultWorkspaceRoot should not run when WA is blocked by last-started');
+      },
       runIssueFetchAndGitPrep: async () => {
         prepCalls++;
         return { prompt: 'x', issueSource: { number: 10, repo: REPO, title: 'Still open' } };
@@ -136,13 +159,21 @@ describe('runCronIssueTracerTick', () => {
       persisted.set(row.repo, row.number);
     };
 
+    const listBoth = async (/** @type {{ repo: string }} */ { repo }) => {
+      if (repo === REPO) return [{ number: 7, title: 'Work' }];
+      if (repo === REPO_P) return [];
+      throw new Error(`unexpected list ${repo}`);
+    };
+
     await runCronIssueTracerTick({
       getSocket: () => sock,
       getOwnerJid: () => OWNER,
-      listOpenGithubIssues: async () => [{ number: 7, title: 'Work' }],
+      listOpenGithubIssues: listBoth,
       resolveIssueRepoSlug: () => REPO,
       readCronPerRepoLastStarted: readLast,
       writeCronPerRepoLastStartedEntry: writeLast,
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => {
         prepCalls++;
@@ -156,10 +187,12 @@ describe('runCronIssueTracerTick', () => {
     await runCronIssueTracerTick({
       getSocket: () => sock,
       getOwnerJid: () => OWNER,
-      listOpenGithubIssues: async () => [{ number: 7, title: 'Work' }],
+      listOpenGithubIssues: listBoth,
       resolveIssueRepoSlug: () => REPO,
       readCronPerRepoLastStarted: readLast,
       writeCronPerRepoLastStartedEntry: writeLast,
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => {
         prepCalls++;
@@ -206,6 +239,42 @@ describe('runCronIssueTracerTick', () => {
     assert.equal(prepFor, '/tmp/ws');
   });
 
+  it('uses Platformer when WhatsappBot’s lowest eligible issue is only blocked by last-started', async () => {
+    const sock = makeMockSock();
+    let prepInfo = /** @type {null | { workspaceRoot: string, issueNumber: number }} */ (null);
+    let listCalls = 0;
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async ({ repo }) => {
+        listCalls++;
+        if (repo === REPO) {
+          return [{ number: 9, title: 'WA task' }];
+        }
+        if (repo === REPO_P) {
+          return [{ number: 4, title: 'Plat task' }];
+        }
+        throw new Error(`unexpected repo list ${repo}`);
+      },
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: async () => new Map([[REPO, 9]]),
+      resolveWorkspaceFromAlias: async () => '/plat/root',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => {
+        throw new Error('getDefaultWorkspaceRoot should not run when WA is blocked by last-started');
+      },
+      runIssueFetchAndGitPrep: async (p) => {
+        prepInfo = { workspaceRoot: p.workspaceRoot, issueNumber: p.issueNumber };
+        return { prompt: 'p', issueSource: { number: 4, repo: REPO_P, title: 'Plat task' } };
+      },
+      runCursorAgentWithPost: async () => {},
+    });
+    assert.ok(listCalls >= 2, 'WhatsappBot and Platformer issue lists should run');
+    assert.ok(prepInfo, 'Platformer path should run prep');
+    assert.equal(prepInfo.workspaceRoot, '/plat/root');
+    assert.equal(prepInfo.issueNumber, 4);
+  });
+
   it('uses Platformer when WhatsappBot has no eligible issues (e.g. only PRD-titled opens)', async () => {
     const sock = makeMockSock();
     let prepInfo = /** @type {null | { workspaceRoot: string, issueNumber: number, alias: string | null }} */ (
@@ -247,6 +316,35 @@ describe('runCronIssueTracerTick', () => {
     assert.equal(prepInfo.workspaceRoot, '/plat/root');
     assert.equal(prepInfo.alias, 'platformer');
     assert.equal(prepInfo.issueNumber, 2);
+  });
+
+  it('does not start Platformer when every open Platformer issue is PRD-titled', async () => {
+    const sock = makeMockSock();
+    let prepCalls = 0;
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async ({ repo }) => {
+        if (repo === REPO) return [{ number: 1, title: 'PRD: wa' }];
+        if (repo === REPO_P) {
+          return [
+            { number: 2, title: 'PRD: plat doc' },
+            { number: 3, title: 'prd-dash' },
+          ];
+        }
+        return [];
+      },
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: async () => new Map(),
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => '/w',
+      runIssueFetchAndGitPrep: async () => {
+        prepCalls++;
+        return { prompt: 'p', issueSource: { number: 1, repo: REPO, title: 'x' } };
+      },
+    });
+    assert.equal(prepCalls, 0, 'no repo should run prep when both repos only have PRD-titled opens');
   });
 
   it('starts work on a different eligible issue when last-started was another number in that repo', async () => {

--- a/test/cronIssueTracer.test.js
+++ b/test/cronIssueTracer.test.js
@@ -53,6 +53,7 @@ function makeMockSock() {
 }
 
 const REPO = 'alexisNorthcoders/WhatsappBot';
+const REPO_P = 'alexisNorthcoders/Platformer';
 const OWNER = '123@s.whatsapp.net';
 
 describe('runCronIssueTracerTick', () => {
@@ -69,7 +70,7 @@ describe('runCronIssueTracerTick', () => {
       getOwnerJid: () => OWNER,
       listOpenGithubIssues: async () => [{ number: 1, title: 'Task' }],
       resolveIssueRepoSlug: () => REPO,
-      readCronLastStartedIssue: async () => null,
+      readCronPerRepoLastStarted: async () => new Map(),
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => null,
       runCursorAgentWithPost: async () => {
@@ -88,7 +89,7 @@ describe('runCronIssueTracerTick', () => {
       getOwnerJid: () => OWNER,
       listOpenGithubIssues: async () => [{ number: 2, title: 'Task' }],
       resolveIssueRepoSlug: () => REPO,
-      readCronLastStartedIssue: async () => null,
+      readCronPerRepoLastStarted: async () => new Map(),
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => ({
         prompt: 'p',
@@ -97,7 +98,7 @@ describe('runCronIssueTracerTick', () => {
       runCursorAgentWithPost: async () => {
         throw 'non-Error rejection';
       },
-      writeCronLastStartedIssue: async (row) => {
+      writeCronPerRepoLastStartedEntry: async (row) => {
         writes.push(row);
       },
     });
@@ -115,11 +116,7 @@ describe('runCronIssueTracerTick', () => {
       getOwnerJid: () => OWNER,
       listOpenGithubIssues: async () => [{ number: 10, title: 'Still open' }],
       resolveIssueRepoSlug: () => REPO,
-      readCronLastStartedIssue: async () => ({
-        repo: REPO,
-        number: 10,
-        savedAt: '2020-01-01T00:00:00.000Z',
-      }),
+      readCronPerRepoLastStarted: async () => new Map([[REPO, 10]]),
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => {
         prepCalls++;
@@ -132,14 +129,11 @@ describe('runCronIssueTracerTick', () => {
   it('after a successful agent run, persists last-started and skips the same issue on the next tick', async () => {
     const sock = makeMockSock();
     let prepCalls = 0;
-    /** @type {{ repo: string, number: number } | null} */
-    let persisted = null;
-    const readLast = async () =>
-      persisted
-        ? { ...persisted, savedAt: 'saved' }
-        : null;
+    /** @type {Map<string, number>} */
+    const persisted = new Map();
+    const readLast = async () => new Map(persisted);
     const writeLast = async (/** @type {{ repo: string, number: number }} */ row) => {
-      persisted = { repo: row.repo, number: row.number };
+      persisted.set(row.repo, row.number);
     };
 
     await runCronIssueTracerTick({
@@ -147,8 +141,8 @@ describe('runCronIssueTracerTick', () => {
       getOwnerJid: () => OWNER,
       listOpenGithubIssues: async () => [{ number: 7, title: 'Work' }],
       resolveIssueRepoSlug: () => REPO,
-      readCronLastStartedIssue: readLast,
-      writeCronLastStartedIssue: writeLast,
+      readCronPerRepoLastStarted: readLast,
+      writeCronPerRepoLastStartedEntry: writeLast,
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => {
         prepCalls++;
@@ -157,15 +151,15 @@ describe('runCronIssueTracerTick', () => {
       runCursorAgentWithPost: async () => {},
     });
     assert.equal(prepCalls, 1);
-    assert.deepEqual(persisted, { repo: REPO, number: 7 });
+    assert.equal(persisted.get(REPO), 7);
 
     await runCronIssueTracerTick({
       getSocket: () => sock,
       getOwnerJid: () => OWNER,
       listOpenGithubIssues: async () => [{ number: 7, title: 'Work' }],
       resolveIssueRepoSlug: () => REPO,
-      readCronLastStartedIssue: readLast,
-      writeCronLastStartedIssue: writeLast,
+      readCronPerRepoLastStarted: readLast,
+      writeCronPerRepoLastStartedEntry: writeLast,
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async () => {
         prepCalls++;
@@ -178,7 +172,84 @@ describe('runCronIssueTracerTick', () => {
     assert.equal(prepCalls, 1);
   });
 
-  it('starts work on a different eligible issue when last-started was another number', async () => {
+  it('does not list or resolve Platformer when WhatsappBot has an eligible issue', async () => {
+    const sock = makeMockSock();
+    let listCalls = 0;
+    let platRootCalls = 0;
+    let prepFor = /** @type {string | null} */ (null);
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async ({ repo }) => {
+        listCalls++;
+        assert.equal(repo, REPO);
+        return [{ number: 1, title: 'WA' }];
+      },
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: async () => new Map(),
+      resolveWorkspaceFromAlias: () => {
+        platRootCalls++;
+        return '/plat';
+      },
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async (p) => {
+        prepFor = p.workspaceRoot;
+        return {
+          prompt: 'p',
+          issueSource: { number: 1, repo: REPO, title: 'WA' },
+        };
+      },
+      runCursorAgentWithPost: async () => {},
+    });
+    assert.equal(listCalls, 1, 'only WhatsappBot issue list should run');
+    assert.equal(platRootCalls, 0);
+    assert.equal(prepFor, '/tmp/ws');
+  });
+
+  it('uses Platformer when WhatsappBot has no eligible issues (e.g. only PRD-titled opens)', async () => {
+    const sock = makeMockSock();
+    let prepInfo = /** @type {null | { workspaceRoot: string, issueNumber: number, alias: string | null }} */ (
+      null
+    );
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async ({ repo }) => {
+        if (repo === REPO) {
+          return [{ number: 5, title: 'PRD: x' }];
+        }
+        if (repo === REPO_P) {
+          return [{ number: 2, title: 'Plat' }];
+        }
+        throw new Error(`unexpected repo list ${repo}`);
+      },
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: async () => new Map(),
+      resolveWorkspaceFromAlias: async (alias) => {
+        assert.equal(alias, 'platformer');
+        return '/plat/root';
+      },
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => {
+        throw new Error('getDefaultWorkspaceRoot should not run for Platformer-only path');
+      },
+      runIssueFetchAndGitPrep: async (p) => {
+        prepInfo = {
+          workspaceRoot: p.workspaceRoot,
+          issueNumber: p.issueNumber,
+          alias: p.workspaceAlias,
+        };
+        return { prompt: 'p', issueSource: { number: 2, repo: REPO_P, title: 'Plat' } };
+      },
+      runCursorAgentWithPost: async () => {},
+    });
+    assert.ok(prepInfo, 'Platformer path should run prep');
+    assert.equal(prepInfo.workspaceRoot, '/plat/root');
+    assert.equal(prepInfo.alias, 'platformer');
+    assert.equal(prepInfo.issueNumber, 2);
+  });
+
+  it('starts work on a different eligible issue when last-started was another number in that repo', async () => {
     const sock = makeMockSock();
     let prepFor = /** @type {number | null} */ (null);
     await runCronIssueTracerTick({
@@ -186,11 +257,7 @@ describe('runCronIssueTracerTick', () => {
       getOwnerJid: () => OWNER,
       listOpenGithubIssues: async () => [{ number: 20, title: 'New' }],
       resolveIssueRepoSlug: () => REPO,
-      readCronLastStartedIssue: async () => ({
-        repo: REPO,
-        number: 3,
-        savedAt: 'old',
-      }),
+      readCronPerRepoLastStarted: async () => new Map([[REPO, 3]]),
       getDefaultWorkspaceRoot: async () => '/tmp/ws',
       runIssueFetchAndGitPrep: async (p) => {
         prepFor = p.issueNumber;
@@ -200,8 +267,41 @@ describe('runCronIssueTracerTick', () => {
         };
       },
       runCursorAgentWithPost: async () => {},
-      writeCronLastStartedIssue: async () => {},
+      writeCronPerRepoLastStartedEntry: async () => {},
     });
     assert.equal(prepFor, 20);
+  });
+
+  it('a Platformer last-started entry does not block a different issue number in that repo', async () => {
+    const sock = makeMockSock();
+    let pLists = 0;
+    const last = new Map([
+      [REPO, 7],
+      [REPO_P, 2],
+    ]);
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async ({ repo }) => {
+        if (repo === REPO_P) pLists++;
+        if (repo === REPO) return [];
+        if (repo === REPO_P) {
+          return [{ number: 3, title: 'C' }];
+        }
+        return [];
+      },
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: async () => last,
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => '/w',
+      runIssueFetchAndGitPrep: async (p) => {
+        assert.equal(p.workspaceRoot, '/plat');
+        assert.equal(p.issueNumber, 3);
+        return { prompt: 'p', issueSource: { number: 3, repo: REPO_P, title: 'C' } };
+      },
+      runCursorAgentWithPost: async () => {},
+    });
+    assert.equal(pLists, 1);
   });
 });

--- a/test/cronLastStartedIssue.test.js
+++ b/test/cronLastStartedIssue.test.js
@@ -3,10 +3,11 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { writeFile } from 'fs/promises';
 import {
   cronLastStartedIssuePath,
-  readCronLastStartedIssue,
-  writeCronLastStartedIssue,
+  readCronPerRepoLastStarted,
+  writeCronPerRepoLastStartedEntry,
 } from '../whatsapp/agents/cronLastStartedIssue.js';
 
 describe('cronLastStartedIssue persistence', () => {
@@ -30,19 +31,33 @@ describe('cronLastStartedIssue persistence', () => {
     }
   });
 
-  it('read returns null when missing or invalid', async () => {
-    assert.equal(await readCronLastStartedIssue(), null);
+  it('read returns empty map when missing or invalid', async () => {
+    assert.equal((await readCronPerRepoLastStarted()).size, 0);
     const path = cronLastStartedIssuePath();
-    const { writeFile } = await import('fs/promises');
     await writeFile(path, '{"foo":1}', 'utf8');
-    assert.equal(await readCronLastStartedIssue(), null);
+    assert.equal((await readCronPerRepoLastStarted()).size, 0);
   });
 
-  it('write then read returns repo, number, savedAt', async () => {
-    await writeCronLastStartedIssue({ repo: 'o/r', number: 26 });
-    const row = await readCronLastStartedIssue();
-    assert.equal(row?.repo, 'o/r');
-    assert.equal(row?.number, 26);
-    assert.ok(String(row?.savedAt || '').length > 0);
+  it('legacy { repo, number } file is kept when merging a new per-repo write', async () => {
+    const path = cronLastStartedIssuePath();
+    await writeFile(
+      path,
+      JSON.stringify({ repo: 'legacy/one', number: 99, savedAt: 'x' }, null, 2),
+      'utf8'
+    );
+    const m0 = await readCronPerRepoLastStarted();
+    assert.equal(m0.get('legacy/one'), 99);
+    await writeCronPerRepoLastStartedEntry({ repo: 'other/m', number: 3 });
+    const m1 = await readCronPerRepoLastStarted();
+    assert.equal(m1.get('legacy/one'), 99);
+    assert.equal(m1.get('other/m'), 3);
+  });
+
+  it('merging writes keeps all repos in one file', async () => {
+    await writeCronPerRepoLastStartedEntry({ repo: 'a/w', number: 7 });
+    await writeCronPerRepoLastStartedEntry({ repo: 'a/p', number: 2 });
+    const m = await readCronPerRepoLastStarted();
+    assert.equal(m.get('a/w'), 7);
+    assert.equal(m.get('a/p'), 2);
   });
 });

--- a/test/cronLastStartedIssue.test.js
+++ b/test/cronLastStartedIssue.test.js
@@ -60,4 +60,28 @@ describe('cronLastStartedIssue persistence', () => {
     assert.equal(m.get('a/w'), 7);
     assert.equal(m.get('a/p'), 2);
   });
+
+  it('rejects invalid repo slugs and leaves the file unchanged', async () => {
+    const path = cronLastStartedIssuePath();
+    await writeFile(path, JSON.stringify({ perRepo: { 'ok/r': 1 }, savedAt: 'x' }, null, 2), 'utf8');
+    const before = await readCronPerRepoLastStarted();
+    await assert.rejects(
+      () => writeCronPerRepoLastStartedEntry({ repo: 'not-a-valid-slug', number: 2 }),
+      /invalid repo slug/i
+    );
+    assert.deepEqual(await readCronPerRepoLastStarted(), before);
+  });
+
+  it('rejects invalid issue numbers and leaves the file unchanged', async () => {
+    const path = cronLastStartedIssuePath();
+    await writeFile(path, JSON.stringify({ perRepo: { 'ok/r': 1 }, savedAt: 'x' }, null, 2), 'utf8');
+    const before = await readCronPerRepoLastStarted();
+    for (const number of [0, -1, 1.5, NaN, Number.POSITIVE_INFINITY]) {
+      await assert.rejects(
+        () => writeCronPerRepoLastStartedEntry({ repo: 'ok/r', number }),
+        /invalid issue number/i
+      );
+    }
+    assert.deepEqual(await readCronPerRepoLastStarted(), before);
+  });
 });

--- a/whatsapp/agents/cronIssueTracer.js
+++ b/whatsapp/agents/cronIssueTracer.js
@@ -1,16 +1,17 @@
 import {
   listOpenGithubIssues,
   resolveIssueRepoSlug,
+  resolveIssueRepoSlugForWorkspace,
 } from './ghIssueForCursor.js';
-import { getDefaultWorkspaceRoot } from '../cursorWorkspaces.js';
+import { getDefaultWorkspaceRoot, resolveWorkspaceFromAlias } from '../cursorWorkspaces.js';
 import {
   tryAcquireAgentBusyLock,
   releaseAgentBusyLock,
   isCursorAgentBusy,
 } from './cursorAgentBusy.js';
 import {
-  readCronLastStartedIssue,
-  writeCronLastStartedIssue,
+  readCronPerRepoLastStarted,
+  writeCronPerRepoLastStartedEntry,
 } from './cronLastStartedIssue.js';
 import {
   runIssueFetchAndGitPrep,
@@ -19,6 +20,12 @@ import {
 } from './cursorIssuePipeline.js';
 
 const DEFAULT_MS = 10 * 60 * 1000;
+
+/** Must match the allowlisted `CURSOR_WORKSPACE_MAP` key for the secondary repo. */
+const CRON_PLATFORMER_WORKSPACE_ALIAS = (() => {
+  const t = (process.env.CRON_PLATFORMER_WORKSPACE_ALIAS || 'platformer').trim();
+  return t || 'platformer';
+})();
 
 let intervalId = /** @type {ReturnType<typeof setInterval> | null} */ (null);
 let inFlight = false;
@@ -52,21 +59,25 @@ function truncateErrorSummary(err, max = 1500) {
  *   logger?: { info?: (o: object | string) => void, warn?: (o: object | string) => void },
  *   listOpenGithubIssues?: typeof listOpenGithubIssues,
  *   resolveIssueRepoSlug?: typeof resolveIssueRepoSlug,
+ *   resolveIssueRepoSlugForWorkspace?: typeof resolveIssueRepoSlugForWorkspace,
  *   getDefaultWorkspaceRoot?: typeof getDefaultWorkspaceRoot,
- *   readCronLastStartedIssue?: typeof readCronLastStartedIssue,
- *   writeCronLastStartedIssue?: typeof writeCronLastStartedIssue,
+ *   resolveWorkspaceFromAlias?: typeof resolveWorkspaceFromAlias,
+ *   readCronPerRepoLastStarted?: typeof readCronPerRepoLastStarted,
+ *   writeCronPerRepoLastStartedEntry?: typeof writeCronPerRepoLastStartedEntry,
  *   tryAcquireAgentBusyLock?: typeof tryAcquireAgentBusyLock,
  *   releaseAgentBusyLock?: typeof releaseAgentBusyLock,
  *   isCursorAgentBusy?: typeof isCursorAgentBusy,
  *   runIssueFetchAndGitPrep?: typeof runIssueFetchAndGitPrep,
  *   runCursorAgentWithPost?: typeof runCursorAgentWithPost,
+ *   cronPlatformerAlias?: string,
  * }} CronIssueTracerTickDeps
  */
 
 /**
  * One cron evaluation cycle (exported for tests; production uses `startCronIssueTracer`).
- * Persists last-started only after `runCursorAgentWithPost` completes without throwing, so a crash
- * or unexpected failure before that point does not suppress retries for the same open issue.
+ * Persists last-started per GitHub repo only after `runCursorAgentWithPost` completes without
+ * throwing, so a crash or unexpected failure before that point does not suppress retries for the
+ * same open issue in that repo.
  *
  * @param {CronIssueTracerTickDeps} [deps]
  */
@@ -76,14 +87,17 @@ export async function runCronIssueTracerTick(deps = {}) {
   const logger = deps.logger;
   const listIssues = deps.listOpenGithubIssues ?? listOpenGithubIssues;
   const resolveRepo = deps.resolveIssueRepoSlug ?? resolveIssueRepoSlug;
+  const resolveForWs = deps.resolveIssueRepoSlugForWorkspace ?? resolveIssueRepoSlugForWorkspace;
   const getWorkspace = deps.getDefaultWorkspaceRoot ?? getDefaultWorkspaceRoot;
-  const readLast = deps.readCronLastStartedIssue ?? readCronLastStartedIssue;
-  const writeLast = deps.writeCronLastStartedIssue ?? writeCronLastStartedIssue;
+  const resolvePlatRoot = deps.resolveWorkspaceFromAlias ?? resolveWorkspaceFromAlias;
+  const readPerRepo = deps.readCronPerRepoLastStarted ?? readCronPerRepoLastStarted;
+  const writePerRepo = deps.writeCronPerRepoLastStartedEntry ?? writeCronPerRepoLastStartedEntry;
   const tryLock = deps.tryAcquireAgentBusyLock ?? tryAcquireAgentBusyLock;
   const releaseLock = deps.releaseAgentBusyLock ?? releaseAgentBusyLock;
   const agentBusy = deps.isCursorAgentBusy ?? isCursorAgentBusy;
   const runPrep = deps.runIssueFetchAndGitPrep ?? runIssueFetchAndGitPrep;
   const runAgent = deps.runCursorAgentWithPost ?? runCursorAgentWithPost;
+  const platformerAlias = (deps.cronPlatformerAlias ?? CRON_PLATFORMER_WORKSPACE_ALIAS).trim() || 'platformer';
 
   let phase = 'initial checks';
   /** @type {string | null} */
@@ -102,19 +116,121 @@ export async function runCronIssueTracerTick(deps = {}) {
     const ownerJid = (getOwnerJid() || '').trim();
     if (!ownerJid) return;
 
-    phase = 'listing open GitHub issues';
-    const repo = resolveRepo();
-    repoForMsg = repo;
-    const rows = await listIssues({ repo });
-    const next = pickNextEligibleIssue(rows);
-    if (next == null) {
-      return;
-    }
-    issueNumForMsg = next.number;
+    /**
+     * @param {'WhatsappBot' | 'Platformer'} cronLabel
+     * @param {string} gitRepo
+     * @param {{ number: number, title: string }} next
+     * @param {string} workspaceRoot
+     * @param {string | null} workspaceAlias
+     */
+    const runCronIssueJob = async (cronLabel, gitRepo, next, workspaceRoot, workspaceAlias) => {
+      repoForMsg = gitRepo;
+      issueNumForMsg = next.number;
 
-    phase = 'reading persisted last-started issue';
-    const last = await readLast();
-    if (last && last.repo === repo && last.number === next.number) {
+      const startText = [
+        'Cron: starting the Cursor *issue* workflow (same as `cursor issue:` from WhatsApp).',
+        '',
+        `*Repo:* ${gitRepo}`,
+        `*Issue:* #${next.number}`,
+        `*Title:* ${next.title}`,
+        '',
+        'Fetching issue and preparing the workspace next…',
+      ].join('\n');
+      phase = 'sending start notification to owner';
+      await sock.sendMessage(ownerJid, { text: startText });
+
+      phase = 'issue fetch / git prep';
+      const prepped = await runPrep({
+        sock,
+        recipientJid: ownerJid,
+        issueNumber: next.number,
+        extraInstructions: '',
+        workspaceRoot,
+        workspaceAlias,
+        sendProgressMessages: false,
+      });
+
+      if (!prepped) {
+        await sock.sendMessage(ownerJid, {
+          text: `Cron (${cronLabel}): could not start work on #${next.number} in \`${gitRepo}\` (step: issue fetch or git prep failed; see the message above if one was sent).`,
+        });
+        return;
+      }
+
+      const issueMatch = { issueNumber: next.number, extraInstructions: '' };
+      phase = 'cursor agent run and post-run automation';
+      try {
+        await runAgent({
+          sock,
+          recipientJid: ownerJid,
+          prompt: prepped.prompt,
+          repo: workspaceRoot,
+          issueMatch,
+          issueSource: prepped.issueSource,
+          joplinSource: null,
+          sendProgressMessages: false,
+        });
+        phase = 'persisting last-started issue';
+        await writePerRepo({ repo: gitRepo, number: next.number });
+      } catch (runErr) {
+        const e = errorMessageFromUnknown(runErr);
+        try {
+          await sock.sendMessage(ownerJid, {
+            text: [
+              `Cron (${cronLabel}): the Cursor run for \`${gitRepo}\` issue #${next.number} failed during: ${phase}.`,
+              '',
+              truncateErrorSummary(e),
+            ].join('\n'),
+          });
+        } catch (sendE) {
+          logger?.warn(
+            { err: errorMessageFromUnknown(sendE) },
+            'cron issue tracer: failed to notify owner of run error'
+          );
+        }
+      }
+    };
+
+    phase = 'reading last-started by repo';
+    const lastByRepo = await readPerRepo();
+
+    phase = 'listing open GitHub issues (WhatsappBot)';
+    const whRepo = resolveRepo();
+    const whRows = await listIssues({ repo: whRepo });
+    const nextWh = pickNextEligibleIssue(whRows);
+    if (nextWh != null) {
+      if (lastByRepo.get(whRepo) === nextWh.number) {
+        return;
+      }
+    } else {
+      phase = 'resolving secondary repo (Platformer)';
+      /** @type {string} */
+      let platRoot;
+      /** @type {string} */
+      let platGitRepo;
+      try {
+        platRoot = await resolvePlatRoot(platformerAlias);
+        platGitRepo = await resolveForWs(platRoot, platformerAlias);
+      } catch (e) {
+        const msg = errorMessageFromUnknown(e);
+        logger?.warn({ err: e }, `cron issue tracer: Platformer not available: ${msg}`);
+        return;
+      }
+      phase = 'listing open GitHub issues (Platformer)';
+      const pRows = await listIssues({ repo: platGitRepo });
+      const nextPlat = pickNextEligibleIssue(pRows);
+      if (nextPlat == null) {
+        return;
+      }
+      if (lastByRepo.get(platGitRepo) === nextPlat.number) {
+        return;
+      }
+      if (!tryLock()) {
+        return;
+      }
+      acquired = true;
+
+      await runCronIssueJob('Platformer', platGitRepo, nextPlat, platRoot, platformerAlias);
       return;
     }
 
@@ -135,68 +251,7 @@ export async function runCronIssueTracerTick(deps = {}) {
       return;
     }
 
-    const startText = [
-      'Cron: starting the Cursor *issue* workflow (same as `cursor issue:` from WhatsApp).',
-      '',
-      `*Repo:* ${repo}`,
-      `*Issue:* #${next.number}`,
-      `*Title:* ${next.title}`,
-      '',
-      'Fetching issue and preparing the workspace next…',
-    ].join('\n');
-    phase = 'sending start notification to owner';
-    await sock.sendMessage(ownerJid, { text: startText });
-
-    phase = 'issue fetch / git prep';
-    const prepped = await runPrep({
-      sock,
-      recipientJid: ownerJid,
-      issueNumber: next.number,
-      extraInstructions: '',
-      workspaceRoot,
-      workspaceAlias: null,
-      sendProgressMessages: false,
-    });
-
-    if (!prepped) {
-      await sock.sendMessage(ownerJid, {
-        text: `Cron (WhatsappBot): could not start work on #${next.number} in \`${repo}\` (step: issue fetch or git prep failed; see the message above if one was sent).`,
-      });
-      return;
-    }
-
-    const issueMatch = { issueNumber: next.number, extraInstructions: '' };
-    phase = 'cursor agent run and post-run automation';
-    try {
-      await runAgent({
-        sock,
-        recipientJid: ownerJid,
-        prompt: prepped.prompt,
-        repo: workspaceRoot,
-        issueMatch,
-        issueSource: prepped.issueSource,
-        joplinSource: null,
-        sendProgressMessages: false,
-      });
-      phase = 'persisting last-started issue';
-      await writeLast({ repo, number: next.number });
-    } catch (runErr) {
-      const e = errorMessageFromUnknown(runErr);
-      try {
-        await sock.sendMessage(ownerJid, {
-          text: [
-            `Cron (WhatsappBot): the Cursor run for \`${repo}\` issue #${next.number} failed during: ${phase}.`,
-            '',
-            truncateErrorSummary(e),
-          ].join('\n'),
-        });
-      } catch (sendE) {
-        logger?.warn(
-          { err: errorMessageFromUnknown(sendE) },
-          'cron issue tracer: failed to notify owner of run error'
-        );
-      }
-    }
+    await runCronIssueJob('WhatsappBot', whRepo, nextWh, workspaceRoot, null);
   } catch (e) {
     const err = errorMessageFromUnknown(e);
     logger?.warn({ err: e }, `cron issue tracer: ${err}`);
@@ -209,7 +264,7 @@ export async function runCronIssueTracerTick(deps = {}) {
             ? `issue \`${repoForMsg}#${issueNumForMsg}\` — `
             : '';
         await sock.sendMessage(ownerJid, {
-          text: `Cron (WhatsappBot) tick failed while ${issuePart}step *${phase}*: ${truncateErrorSummary(err)}`,
+          text: `Cron tick failed while ${issuePart}step *${phase}*: ${truncateErrorSummary(err)}`,
         });
       } catch (sendE) {
         logger?.warn(
@@ -226,9 +281,9 @@ export async function runCronIssueTracerTick(deps = {}) {
 }
 
 /**
- * Interval job: if an eligible WhatsappBot issue exists and the Cursor agent is free, run the
- * same pipeline as a manual `cursor issue:<n>` (fetch, git prep, agent, post-run automation).
- * Persists last-started (repo + issue) so the same open issue is not re-dispatched every tick.
+ * Interval job: if the Cursor agent is free, find the next eligible open issue, preferring
+ * this bot’s repo, then a secondary (Platformer) allowlisted workspace with matching issue-repo map.
+ * Runs the same pipeline as manual `cursor issue:…` (fetch, git prep, agent, post-run automation).
  * @param {{
  *   getSocket: () => import('@whiskeysockets/baileys').WASocket | null | undefined,
  *   getOwnerJid: () => string | null | undefined,

--- a/whatsapp/agents/cronIssueTracer.js
+++ b/whatsapp/agents/cronIssueTracer.js
@@ -43,6 +43,21 @@ export function pickNextEligibleIssue(rows) {
 }
 
 /**
+ * Lowest PRD-filtered eligible issue for `gitRepo` that is not suppressed by per-repo last-started.
+ *
+ * @param {{ number: number, title: string }[]} rows
+ * @param {string} gitRepo
+ * @param {Map<string, number>} lastByRepo
+ * @returns {{ number: number, title: string } | null}
+ */
+export function pickNextRunnableIssueForRepo(rows, gitRepo, lastByRepo) {
+  const next = pickNextEligibleIssue(rows);
+  if (next == null) return null;
+  if (lastByRepo.get(gitRepo) === next.number) return null;
+  return next;
+}
+
+/**
  * @param {string} err
  * @param {number} [max]
  */
@@ -197,61 +212,55 @@ export async function runCronIssueTracerTick(deps = {}) {
     phase = 'listing open GitHub issues (WhatsappBot)';
     const whRepo = resolveRepo();
     const whRows = await listIssues({ repo: whRepo });
-    const nextWh = pickNextEligibleIssue(whRows);
+    const nextWh = pickNextRunnableIssueForRepo(whRows, whRepo, lastByRepo);
+
     if (nextWh != null) {
-      if (lastByRepo.get(whRepo) === nextWh.number) {
-        return;
-      }
-    } else {
-      phase = 'resolving secondary repo (Platformer)';
-      /** @type {string} */
-      let platRoot;
-      /** @type {string} */
-      let platGitRepo;
-      try {
-        platRoot = await resolvePlatRoot(platformerAlias);
-        platGitRepo = await resolveForWs(platRoot, platformerAlias);
-      } catch (e) {
-        const msg = errorMessageFromUnknown(e);
-        logger?.warn({ err: e }, `cron issue tracer: Platformer not available: ${msg}`);
-        return;
-      }
-      phase = 'listing open GitHub issues (Platformer)';
-      const pRows = await listIssues({ repo: platGitRepo });
-      const nextPlat = pickNextEligibleIssue(pRows);
-      if (nextPlat == null) {
-        return;
-      }
-      if (lastByRepo.get(platGitRepo) === nextPlat.number) {
-        return;
-      }
       if (!tryLock()) {
         return;
       }
       acquired = true;
 
-      await runCronIssueJob('Platformer', platGitRepo, nextPlat, platRoot, platformerAlias);
+      let workspaceRoot;
+      phase = 'resolving default workspace';
+      try {
+        workspaceRoot = await getWorkspace();
+      } catch (e) {
+        const msg = errorMessageFromUnknown(e);
+        await sock.sendMessage(ownerJid, {
+          text: `Cron (WhatsappBot): could not resolve default workspace (step: ${phase}): ${truncateErrorSummary(msg, 2000)}`,
+        });
+        return;
+      }
+
+      await runCronIssueJob('WhatsappBot', whRepo, nextWh, workspaceRoot, null);
       return;
     }
 
+    phase = 'resolving secondary repo (Platformer)';
+    /** @type {string} */
+    let platRoot;
+    /** @type {string} */
+    let platGitRepo;
+    try {
+      platRoot = await resolvePlatRoot(platformerAlias);
+      platGitRepo = await resolveForWs(platRoot, platformerAlias);
+    } catch (e) {
+      const msg = errorMessageFromUnknown(e);
+      logger?.warn({ err: e }, `cron issue tracer: Platformer not available: ${msg}`);
+      return;
+    }
+    phase = 'listing open GitHub issues (Platformer)';
+    const pRows = await listIssues({ repo: platGitRepo });
+    const nextPlat = pickNextRunnableIssueForRepo(pRows, platGitRepo, lastByRepo);
+    if (nextPlat == null) {
+      return;
+    }
     if (!tryLock()) {
       return;
     }
     acquired = true;
 
-    let workspaceRoot;
-    phase = 'resolving default workspace';
-    try {
-      workspaceRoot = await getWorkspace();
-    } catch (e) {
-      const msg = errorMessageFromUnknown(e);
-      await sock.sendMessage(ownerJid, {
-        text: `Cron (WhatsappBot): could not resolve default workspace (step: ${phase}): ${truncateErrorSummary(msg, 2000)}`,
-      });
-      return;
-    }
-
-    await runCronIssueJob('WhatsappBot', whRepo, nextWh, workspaceRoot, null);
+    await runCronIssueJob('Platformer', platGitRepo, nextPlat, platRoot, platformerAlias);
   } catch (e) {
     const err = errorMessageFromUnknown(e);
     logger?.warn({ err: e }, `cron issue tracer: ${err}`);

--- a/whatsapp/agents/cronLastStartedIssue.js
+++ b/whatsapp/agents/cronLastStartedIssue.js
@@ -4,6 +4,8 @@ import { getCursorCliRepoRoot } from './cursorCliAgent.js';
 
 const FILE = 'cron-last-started-issue.json';
 
+const REPO_SLUG_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+
 /**
  * @returns {string} absolute path to the persisted state file
  */
@@ -19,41 +21,67 @@ export function cronLastStartedIssuePath() {
 }
 
 /**
- * @returns {Promise<{ repo: string, number: number, savedAt: string } | null>}
+ * Migrated from a single { repo, number } record to per-repo entries so the cron runner can
+ * track last-started for WhatsappBot and secondary repos (e.g. Platformer) independently.
+ *
+ * @returns {Promise<Map<string, number>>} repo slug → last started issue number
  */
-export async function readCronLastStartedIssue() {
+export async function readCronPerRepoLastStarted() {
   const path = cronLastStartedIssuePath();
+  /** @type {Map<string, number>} */
+  const map = new Map();
+  let raw;
   try {
-    const raw = await fs.readFile(path, 'utf8');
-    const data = JSON.parse(raw);
-    if (
-      !data ||
-      typeof data.repo !== 'string' ||
-      !Number.isFinite(data.number) ||
-      data.number < 1
-    ) {
-      return null;
-    }
-    return {
-      repo: data.repo,
-      number: data.number,
-      savedAt: typeof data.savedAt === 'string' ? data.savedAt : '',
-    };
+    raw = await fs.readFile(path, 'utf8');
   } catch {
-    return null;
+    return map;
   }
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return map;
+  }
+  if (!data || typeof data !== 'object') {
+    return map;
+  }
+  if (data.perRepo && typeof data.perRepo === 'object' && !Array.isArray(data.perRepo)) {
+    for (const [k, v] of Object.entries(data.perRepo)) {
+      if (typeof k !== 'string' || !REPO_SLUG_RE.test(k)) continue;
+      const n = typeof v === 'number' ? v : parseInt(String(v), 10);
+      if (Number.isFinite(n) && n >= 1) {
+        map.set(k, n);
+      }
+    }
+  }
+  if (
+    typeof data.repo === 'string' &&
+    REPO_SLUG_RE.test(data.repo) &&
+    Number.isFinite(data.number) &&
+    data.number >= 1
+  ) {
+    if (!map.has(data.repo)) {
+      map.set(data.repo, data.number);
+    }
+  }
+  return map;
 }
 
 /**
+ * Merges one repo’s last-started issue into the persisted file (new per-repo format).
  * @param {{ repo: string, number: number }} row
  */
-export async function writeCronLastStartedIssue(row) {
+export async function writeCronPerRepoLastStartedEntry(row) {
   const path = cronLastStartedIssuePath();
-  await fs.mkdir(dirname(path), { recursive: true });
+  const map = await readCronPerRepoLastStarted();
+  map.set(row.repo, row.number);
+  const perRepo = Object.fromEntries(
+    [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+  );
   const payload = {
-    repo: row.repo,
-    number: row.number,
+    perRepo,
     savedAt: new Date().toISOString(),
   };
+  await fs.mkdir(dirname(path), { recursive: true });
   await fs.writeFile(path, JSON.stringify(payload, null, 2), 'utf8');
 }

--- a/whatsapp/agents/cronLastStartedIssue.js
+++ b/whatsapp/agents/cronLastStartedIssue.js
@@ -7,6 +7,42 @@ const FILE = 'cron-last-started-issue.json';
 const REPO_SLUG_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
 /**
+ * @param {unknown} n
+ * @returns {n is number}
+ */
+function isValidIssueNumber(n) {
+  return typeof n === 'number' && Number.isInteger(n) && Number.isFinite(n) && n >= 1;
+}
+
+/**
+ * @param {unknown} repo
+ * @returns {repo is string}
+ */
+function isValidRepoSlug(repo) {
+  return typeof repo === 'string' && REPO_SLUG_RE.test(repo);
+}
+
+/**
+ * Ensures callers cannot persist corrupt `perRepo` keys or issue numbers.
+ * @param {unknown} row
+ * @returns {asserts row is { repo: string, number: number }}
+ */
+function assertValidLastStartedWriteRow(row) {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) {
+    throw new TypeError('cron last-started write: row must be a plain object');
+  }
+  const r = /** @type {{ repo?: unknown, number?: unknown }} */ (row);
+  if (!isValidRepoSlug(r.repo)) {
+    throw new TypeError(
+      `cron last-started write: invalid repo slug ${JSON.stringify(r.repo)} (expected owner/name)`
+    );
+  }
+  if (!isValidIssueNumber(r.number)) {
+    throw new TypeError(`cron last-started write: invalid issue number ${String(r.number)}`);
+  }
+}
+
+/**
  * @returns {string} absolute path to the persisted state file
  */
 export function cronLastStartedIssuePath() {
@@ -69,14 +105,18 @@ export async function readCronPerRepoLastStarted() {
 
 /**
  * Merges one repo’s last-started issue into the persisted file (new per-repo format).
+ * Throws if `row.repo` or `row.number` is not a valid persisted shape (bad callers must not rewrite the file).
  * @param {{ repo: string, number: number }} row
  */
 export async function writeCronPerRepoLastStartedEntry(row) {
+  assertValidLastStartedWriteRow(row);
   const path = cronLastStartedIssuePath();
   const map = await readCronPerRepoLastStarted();
   map.set(row.repo, row.number);
   const perRepo = Object.fromEntries(
-    [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+    [...map.entries()]
+      .filter(([k, n]) => isValidRepoSlug(k) && isValidIssueNumber(n))
+      .sort((a, b) => a[0].localeCompare(b[0]))
   );
   const payload = {
     perRepo,


### PR DESCRIPTION
Fixes #27

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-27-cron-add-platformer-repo-support-secondary-prior`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #27

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/27
**State:** OPEN
**Title:** Cron: add Platformer repo support (secondary priority)

## Body
## Parent

#23

## What to build

Extend the cron runner to check two repos in priority order:

1) WhatsappBot
2) Platformer

If WhatsappBot has an eligible issue, it runs that. Only if none are eligible does it check Platformer. Platformer uses its allowlisted workspace alias and correct repo slug mapping.

## Acceptance criteria

- [ ] Cron checks WhatsappBot first, then Platformer
- [ ] If WhatsappBot has an eligible issue, Platformer is not started
- [ ] If WhatsappBot has no eligible issues, Platformer’s lowest-number eligible OPEN issue is selected
- [ ] The same PRD-title ignore rule applies to Platformer
- [ ] “Last started issue” tracking prevents repeated starts per repo

## Blocked by

- Blocked by #26