### PR TITLE
test: Hardening + tests for cron selection, busy lock, and last-… (#28)

### DIFF
--- a/test/cronIssueTracer.test.js
+++ b/test/cronIssueTracer.test.js
@@ -40,6 +40,14 @@ describe('pickNextEligibleIssue', () => {
     const r = pickNextEligibleIssue([{ number: 1, title: 'PRD-foo' }]);
     assert.equal(r, null);
   });
+
+  it('treats leading tab as whitespace for the PRD filter', () => {
+    const r = pickNextEligibleIssue([
+      { number: 1, title: '\tPrD:   product' },
+      { number: 2, title: 'bugfix' },
+    ]);
+    assert.deepEqual(r, { number: 2, title: 'bugfix' });
+  });
 });
 
 describe('pickNextRunnableIssueForRepo', () => {
@@ -76,6 +84,20 @@ describe('runCronIssueTracerTick', () => {
     if (isCursorAgentBusy()) {
       releaseAgentBusyLock();
     }
+  });
+
+  it('returns without listing issues when the agent is already busy', async () => {
+    let listCalls = 0;
+    await runCronIssueTracerTick({
+      getSocket: () => makeMockSock(),
+      getOwnerJid: () => OWNER,
+      isCursorAgentBusy: () => true,
+      listOpenGithubIssues: async () => {
+        listCalls++;
+        return [];
+      },
+    });
+    assert.equal(listCalls, 0);
   });
 
   it('releases the agent busy lock when issue fetch / git prep returns null', async () => {

--- a/test/cronIssueTracer.test.js
+++ b/test/cronIssueTracer.test.js
@@ -48,6 +48,21 @@ describe('pickNextEligibleIssue', () => {
     ]);
     assert.deepEqual(r, { number: 2, title: 'bugfix' });
   });
+
+  it('treats mixed leading whitespace and letter case as PRD-prefixed (case-insensitive prefix)', () => {
+    const r = pickNextEligibleIssue([
+      { number: 1, title: '  \t pRd \t : roadmap item' },
+      { number: 9, title: 'Ship feature' },
+    ]);
+    assert.deepEqual(r, { number: 9, title: 'Ship feature' });
+  });
+
+  it('does not exclude issues whose title merely contains "prd" after other words', () => {
+    const r = pickNextEligibleIssue([
+      { number: 3, title: 'Follow-up from PRD discussion' },
+    ]);
+    assert.deepEqual(r, { number: 3, title: 'Follow-up from PRD discussion' });
+  });
 });
 
 describe('pickNextRunnableIssueForRepo', () => {
@@ -87,17 +102,32 @@ describe('runCronIssueTracerTick', () => {
   });
 
   it('returns without listing issues when the agent is already busy', async () => {
+    assert.equal(isCursorAgentBusy(), false);
+    const sock = makeMockSock();
     let listCalls = 0;
+    let prepCalls = 0;
+    let agentCalls = 0;
     await runCronIssueTracerTick({
-      getSocket: () => makeMockSock(),
+      getSocket: () => sock,
       getOwnerJid: () => OWNER,
       isCursorAgentBusy: () => true,
       listOpenGithubIssues: async () => {
         listCalls++;
         return [];
       },
+      runIssueFetchAndGitPrep: async () => {
+        prepCalls++;
+        return null;
+      },
+      runCursorAgentWithPost: async () => {
+        agentCalls++;
+      },
     });
     assert.equal(listCalls, 0);
+    assert.equal(prepCalls, 0);
+    assert.equal(agentCalls, 0);
+    assert.equal(sock.sent.length, 0, 'owner should not get cron noise while a manual run holds the lock');
+    assert.equal(isCursorAgentBusy(), false, 'cron early-return must not mutate the real busy lock');
   });
 
   it('releases the agent busy lock when issue fetch / git prep returns null', async () => {
@@ -225,6 +255,60 @@ describe('runCronIssueTracerTick', () => {
       },
     });
     assert.equal(prepCalls, 1);
+
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: listBoth,
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: readLast,
+      writeCronPerRepoLastStartedEntry: writeLast,
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async () => {
+        prepCalls++;
+        return { prompt: 'p', issueSource: { number: 7, repo: REPO, title: 'Work' } };
+      },
+      runCursorAgentWithPost: async () => {
+        throw new Error('should not run on third tick either');
+      },
+    });
+    assert.equal(prepCalls, 1, 'persisted last-started must block duplicate auto-starts across ticks');
+  });
+
+  it('prefers WhatsappBot over Platformer when both have eligible issues (repo priority)', async () => {
+    const sock = makeMockSock();
+    let platListed = false;
+    await runCronIssueTracerTick({
+      getSocket: () => sock,
+      getOwnerJid: () => OWNER,
+      listOpenGithubIssues: async ({ repo }) => {
+        if (repo === REPO) {
+          return [{ number: 50, title: 'WA task' }];
+        }
+        if (repo === REPO_P) {
+          platListed = true;
+          return [{ number: 1, title: 'Lower number but secondary repo' }];
+        }
+        throw new Error(`unexpected list ${repo}`);
+      },
+      resolveIssueRepoSlug: () => REPO,
+      readCronPerRepoLastStarted: async () => new Map(),
+      resolveWorkspaceFromAlias: async () => '/plat',
+      resolveIssueRepoSlugForWorkspace: async () => REPO_P,
+      getDefaultWorkspaceRoot: async () => '/tmp/ws',
+      runIssueFetchAndGitPrep: async (p) => {
+        assert.equal(p.issueNumber, 50);
+        assert.equal(p.workspaceRoot, '/tmp/ws');
+        return {
+          prompt: 'p',
+          issueSource: { number: 50, repo: REPO, title: 'WA task' },
+        };
+      },
+      runCursorAgentWithPost: async () => {},
+    });
+    assert.equal(platListed, false, 'Platformer must not be consulted when WhatsappBot still has runnable work');
   });
 
   it('does not list or resolve Platformer when WhatsappBot has an eligible issue', async () => {

--- a/test/cursorCommand.test.js
+++ b/test/cursorCommand.test.js
@@ -9,6 +9,21 @@ import cursorCommand from '../whatsapp/commands/cursor.js';
 
 const SENDER = '15551234567@s.whatsapp.net';
 
+const GROUP_JID = '120363123456@g.us';
+
+/** Mimics Baileys `msg` shape for a group relay (`sender` is the group; participant is the actor). */
+function productionLikeGroupMsg() {
+  return {
+    key: {
+      remoteJid: GROUP_JID,
+      fromMe: false,
+      participant: '15551234567@s.whatsapp.net',
+      id: 'ABC123',
+    },
+    messageStubParameters: [],
+  };
+}
+
 describe('cursor command (manual)', () => {
   beforeEach(() => {
     process.env.MY_PHONE = '15551234567';
@@ -32,10 +47,34 @@ describe('cursor command (manual)', () => {
     };
 
     assert.equal(tryAcquireAgentBusyLock(), true);
-    await cursorCommand(sock, SENDER, 'cursor fix the bug in auth', { key: {} });
+    try {
+      await cursorCommand(sock, SENDER, 'cursor fix the bug in auth', { key: {} });
 
-    assert.equal(sent.length, 1);
-    assert.match(sent[0].text, /busy/i);
-    assert.equal(isCursorAgentBusy(), true);
+      assert.equal(sent.length, 1);
+      assert.match(sent[0].text, /busy/i);
+      assert.equal(isCursorAgentBusy(), true);
+    } finally {
+      releaseAgentBusyLock();
+    }
+  });
+
+  it('rejects busy for cursor issue:… shape with production-like msg metadata (before pipeline)', async () => {
+    const sent = [];
+    const sock = {
+      sendMessage: async (/** @type {string} */ jid, /** @type {{ text?: string }} */ content) => {
+        sent.push({ jid, text: String(content?.text ?? '') });
+      },
+    };
+
+    assert.equal(tryAcquireAgentBusyLock(), true);
+    try {
+      await cursorCommand(sock, GROUP_JID, 'cursor issue:88 add regression coverage', productionLikeGroupMsg());
+
+      assert.equal(sent.length, 1);
+      assert.match(sent[0].text, /busy/i);
+      assert.equal(isCursorAgentBusy(), true);
+    } finally {
+      releaseAgentBusyLock();
+    }
   });
 });

--- a/test/cursorCommand.test.js
+++ b/test/cursorCommand.test.js
@@ -1,0 +1,41 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  tryAcquireAgentBusyLock,
+  releaseAgentBusyLock,
+  isCursorAgentBusy,
+} from '../whatsapp/agents/cursorAgentBusy.js';
+import cursorCommand from '../whatsapp/commands/cursor.js';
+
+const SENDER = '15551234567@s.whatsapp.net';
+
+describe('cursor command (manual)', () => {
+  beforeEach(() => {
+    process.env.MY_PHONE = '15551234567';
+    if (isCursorAgentBusy()) {
+      releaseAgentBusyLock();
+    }
+  });
+
+  afterEach(() => {
+    if (isCursorAgentBusy()) {
+      releaseAgentBusyLock();
+    }
+  });
+
+  it('rejects with a busy message when the single-agent lock is already held (freeform prompt)', async () => {
+    const sent = [];
+    const sock = {
+      sendMessage: async (/** @type {string} */ jid, /** @type {{ text?: string }} */ content) => {
+        sent.push({ jid, text: String(content?.text ?? '') });
+      },
+    };
+
+    assert.equal(tryAcquireAgentBusyLock(), true);
+    await cursorCommand(sock, SENDER, 'cursor fix the bug in auth', { key: {} });
+
+    assert.equal(sent.length, 1);
+    assert.match(sent[0].text, /busy/i);
+    assert.equal(isCursorAgentBusy(), true);
+  });
+});


### PR DESCRIPTION
Fixes #28

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-28-hardening-tests-for-cron-selection-busy-lock-and`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #28

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/28
**State:** OPEN
**Title:** Hardening + tests for cron selection, busy lock, and last-started behavior

## Body
## Parent

#23

## What to build

Add automated tests and basic hardening around the issue-cron runner and the single-agent busy lock. Focus on externally observable behavior with mocked GitHub CLI outputs and deterministic scheduling.

## Acceptance criteria

- [ ] Tests cover PRD-title filtering (case-insensitive, whitespace)
- [ ] Tests cover lowest-number selection
- [ ] Tests cover repo priority order (WhatsappBot before Platformer)
- [ ] Tests cover “busy” rejection for manual `cursor ...`
- [ ] Tests cover “last started issue” persistence preventing repeated auto-starts

## Blocked by

- Blocked by #27