### PR TITLE
fix: cursorPostRun skips push/PR/review when agent already commi… (#35)

### DIFF
--- a/test/cursorPostRunGitActivity.test.js
+++ b/test/cursorPostRunGitActivity.test.js
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'child_process';
+import { mkdtemp, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  getPostRunReviewDiffText,
+  getRepoHeadShaFull,
+  maybeCommitReviewEmail,
+} from '../whatsapp/agents/cursorPostRun.js';
+
+const execFileAsync = promisify(execFile);
+
+/** @param {string} repo */
+async function git(repo, args) {
+  const { stdout } = await execFileAsync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+  return stdout.trim();
+}
+
+async function initBareRepoWithMain() {
+  const repo = await mkdtemp(join(tmpdir(), 'wa-postrun-'));
+  await execFileAsync('git', ['-C', repo, 'init'], { encoding: 'utf8' });
+  await git(repo, ['config', 'user.email', 'test@test.local']);
+  await git(repo, ['config', 'user.name', 'test']);
+  await writeFile(join(repo, 'README.md'), 'v0\n', 'utf8');
+  await git(repo, ['add', 'README.md']);
+  await git(repo, ['commit', '-m', 'init']);
+  try {
+    await git(repo, ['branch', '-M', 'main']);
+  } catch {
+    /* older git may already use master — rename if needed */
+    const b = await git(repo, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (b === 'master') await git(repo, ['branch', '-M', 'main']);
+  }
+  return repo;
+}
+
+describe('getPostRunReviewDiffText', () => {
+  it('clean + HEAD moved: aggregates multiple commits vs base (not only git show HEAD)', async () => {
+    const repo = await initBareRepoWithMain();
+    await git(repo, ['checkout', '-b', 'cursor/issue-35-work']);
+    await writeFile(join(repo, 'a.txt'), 'a\n', 'utf8');
+    await git(repo, ['add', 'a.txt']);
+    await git(repo, ['commit', '-m', 'add a']);
+    await writeFile(join(repo, 'b.txt'), 'b\n', 'utf8');
+    await git(repo, ['add', 'b.txt']);
+    await git(repo, ['commit', '-m', 'add b']);
+    const pre = await git(repo, ['rev-parse', 'HEAD~2']);
+    const diff = await getPostRunReviewDiffText(
+      repo,
+      { prBase: 'main', branchName: 'cursor/issue-35-work' },
+      { dirty: false, headMoved: true },
+      pre,
+      true
+    );
+    assert.match(diff, /a\.txt/);
+    assert.match(diff, /b\.txt/);
+  });
+
+  it('dirty tree: uses working-tree / staged diff path (delegates to getDiffText)', async () => {
+    const repo = await initBareRepoWithMain();
+    await writeFile(join(repo, 'README.md'), 'v0\nmodified\n', 'utf8');
+    const diff = await getPostRunReviewDiffText(
+      repo,
+      { prBase: 'main' },
+      { dirty: true, headMoved: false },
+      null,
+      false
+    );
+    assert.match(diff, /README\.md/);
+  });
+});
+
+describe('maybeCommitReviewEmail git gating', () => {
+  const saved = {};
+
+  beforeEach(() => {
+    for (const k of [
+      'CURSOR_POST_RUN',
+      'CURSOR_POST_RUN_PUSH',
+      'CURSOR_POST_RUN_PR',
+      'CURSOR_POST_RUN_POLL_MS',
+      'CURSOR_POST_RUN_MAX_WAIT_MS',
+      'CURSOR_POST_RUN_LOG',
+      'OPENAI_API_KEY',
+    ]) {
+      saved[k] = process.env[k];
+    }
+    process.env.CURSOR_POST_RUN = '1';
+    process.env.CURSOR_POST_RUN_PUSH = '0';
+    process.env.CURSOR_POST_RUN_PR = '0';
+    process.env.CURSOR_POST_RUN_LOG = '0';
+    process.env.CURSOR_POST_RUN_POLL_MS = '0';
+    process.env.CURSOR_POST_RUN_MAX_WAIT_MS = '40';
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('clean tree + unchanged HEAD: skips with clean_after_wait', async () => {
+    const repo = await initBareRepoWithMain();
+    const pre = await getRepoHeadShaFull(repo);
+    const post = await maybeCommitReviewEmail({
+      repo,
+      userPrompt: 'unit test',
+      agentRunOk: true,
+      issueMode: { number: 35 },
+      preAgentHeadSha: pre,
+    });
+    assert.equal(post.ran, false);
+    assert.equal(post.skipReason, 'clean_after_wait');
+  });
+
+  it('clean tree + new commit(s): runs post-run without empty_diff (uses pre…HEAD when branch tip equals base)', async () => {
+    const repo = await initBareRepoWithMain();
+    const pre = await getRepoHeadShaFull(repo);
+    await writeFile(join(repo, 'feature.txt'), 'ok\n', 'utf8');
+    await git(repo, ['add', 'feature.txt']);
+    await git(repo, ['commit', '-m', 'agent commit']);
+    const post = await maybeCommitReviewEmail({
+      repo,
+      userPrompt: 'unit test',
+      agentRunOk: true,
+      issueMode: { number: 35 },
+      preAgentHeadSha: pre,
+    });
+    assert.equal(post.ran, true);
+    assert.notEqual(post.skipReason, 'empty_diff');
+    assert.equal(post.commit?.ok, true);
+    assert.ok(post.review && post.review.length > 0);
+  });
+
+  it('dirty tree: tryCommit then proceeds (no empty_diff)', async () => {
+    const repo = await initBareRepoWithMain();
+    const pre = await getRepoHeadShaFull(repo);
+    await writeFile(join(repo, 'wip.txt'), 'wip\n', 'utf8');
+    const post = await maybeCommitReviewEmail({
+      repo,
+      userPrompt: 'unit test dirty',
+      agentRunOk: true,
+      issueMode: { number: 36 },
+      preAgentHeadSha: pre,
+    });
+    assert.equal(post.ran, true);
+    assert.notEqual(post.skipReason, 'empty_diff');
+    assert.equal(post.commit?.ok, true);
+    assert.ok(post.review && post.review.length > 0);
+  });
+});

--- a/whatsapp/agents/cursorIssuePipeline.js
+++ b/whatsapp/agents/cursorIssuePipeline.js
@@ -2,7 +2,11 @@ import { join } from 'path';
 import { runCursorCliAgent } from './cursorCliAgent.js';
 import { setPendingCursorRun, clearPendingCursorRun } from './cursorCliPending.js';
 import { logAgentInvocation } from './agentUsageLog.js';
-import { maybeCommitReviewEmail, prepareWorkspaceForGithubIssue } from './cursorPostRun.js';
+import {
+  getRepoHeadShaFull,
+  maybeCommitReviewEmail,
+  prepareWorkspaceForGithubIssue,
+} from './cursorPostRun.js';
 import { fetchGhIssuePromptText } from './ghIssueForCursor.js';
 
 const WA_TEXT_MAX = 4096;
@@ -199,6 +203,8 @@ export async function runCursorAgentWithPost(p) {
   let outcome = 'error';
   let result;
   let delivered = false;
+  /** Snapshot of `git rev-parse HEAD` before the CLI agent (issue runs only); used by post-run when the agent commits. */
+  let preAgentHeadSha = null;
 
   try {
     const sourceHint = issueSource
@@ -211,6 +217,14 @@ export async function runCursorAgentWithPost(p) {
         text:
           `Running Cursor agent in ${repo} …${sourceHint}\n\nLive log (on the Pi):\n${logPath}\n\ntail -f ${logRel}`,
       });
+    }
+
+    if (issueMatch) {
+      try {
+        preAgentHeadSha = await getRepoHeadShaFull(repo);
+      } catch {
+        preAgentHeadSha = null;
+      }
     }
 
     result = await runCursorCliAgent(prompt, { runId, workspaceRoot: repo });
@@ -256,6 +270,7 @@ export async function runCursorAgentWithPost(p) {
         userPrompt: prompt,
         agentRunOk,
         issueMode: issueMatch ? { number: issueMatch.issueNumber } : null,
+        preAgentHeadSha,
       });
       if (post.note) {
         await sock.sendMessage(recipientJid, { text: post.note });

--- a/whatsapp/agents/cursorPostRun.js
+++ b/whatsapp/agents/cursorPostRun.js
@@ -725,45 +725,91 @@ async function getStatusPorcelain(repo) {
   return stdout.trim();
 }
 
+/** @param {string} repo */
+async function getHeadShaFull(repo) {
+  const { stdout } = await execGit(['rev-parse', 'HEAD'], repo);
+  return stdout.trim();
+}
+
+/** @param {string} repo */
+async function getHeadShaShort(repo) {
+  const { stdout } = await execGit(['rev-parse', '--short', 'HEAD'], repo);
+  return stdout.trim();
+}
+
+/** @param {string} repo */
+async function getLastCommitSubjectLine(repo) {
+  const { stdout } = await execGit(['log', '-1', '--format=%s'], repo);
+  const s = stdout.trim();
+  return s || 'Cursor CLI update';
+}
+
 /**
- * Wait until `git status` shows changes or timeout. Avoids racing the agent process exit.
- * @returns {Promise<{ dirty: boolean, porcelain: string, waitedMs: number, polls: number }>}
+ * Full `HEAD` object name (for comparing before/after the agent).
+ * @param {string} repo
+ * @returns {Promise<string>}
  */
-async function waitForDirtyWorkspace(repo) {
+export async function getRepoHeadShaFull(repo) {
+  return getHeadShaFull(repo);
+}
+
+/**
+ * Wait until uncommitted changes appear **or** `HEAD` differs from `preAgentHeadSha` (agent committed).
+ * When `preAgentHeadSha` is omitted, only porcelain (dirty) is considered — legacy behaviour.
+ * @param {string} repo
+ * @param {string | null | undefined} preAgentHeadSha
+ * @returns {Promise<{ dirty: boolean, headMoved: boolean, porcelain: string, waitedMs: number, polls: number }>}
+ */
+async function waitForAgentGitActivity(repo, preAgentHeadSha) {
+  const pre = typeof preAgentHeadSha === 'string' ? preAgentHeadSha.trim() : '';
+  const trackHead = pre.length > 0;
   const start = Date.now();
   let polls = 0;
   while (Date.now() - start < MAX_WAIT_MS) {
     polls++;
     let porcelain;
+    let headNow = '';
     try {
       porcelain = await getStatusPorcelain(repo);
+      if (trackHead) headNow = await getHeadShaFull(repo);
     } catch (e) {
-      logPost('git status --porcelain failed', e.stderr || e.message || String(e));
+      logPost('waitForAgentGitActivity git probe failed', e.stderr || e.message || String(e));
       throw e;
     }
     const dirty = Boolean(porcelain);
+    const headMoved = trackHead && headNow !== pre;
+    const statusBits = `dirty=${dirty} headMoved=${headMoved}`;
     logPost(
-      `poll #${polls} (${Date.now() - start}ms) dirty=${dirty}`,
+      `poll #${polls} (${Date.now() - start}ms) ${statusBits}`,
       dirty ? porcelain.split('\n').slice(0, 8).join('\n') : '(clean)'
     );
-    if (dirty) {
-      return { dirty: true, porcelain, waitedMs: Date.now() - start, polls };
+    if (dirty || headMoved) {
+      return {
+        dirty,
+        headMoved,
+        porcelain,
+        waitedMs: Date.now() - start,
+        polls,
+      };
     }
     await new Promise((r) => setTimeout(r, POLL_MS));
   }
   let porcelain = '';
+  let headNow = '';
   try {
     porcelain = await getStatusPorcelain(repo);
+    if (trackHead) headNow = await getHeadShaFull(repo);
   } catch (e) {
-    logPost('git status (final) failed', e.stderr || e.message || String(e));
+    logPost('waitForAgentGitActivity (final) failed', e.stderr || e.message || String(e));
     throw e;
   }
   const dirty = Boolean(porcelain);
+  const headMoved = trackHead && headNow !== pre;
   logPost(
-    `timeout ${MAX_WAIT_MS}ms after ${polls} polls dirty=${dirty}`,
+    `timeout ${MAX_WAIT_MS}ms after ${polls} polls dirty=${dirty} headMoved=${headMoved}`,
     dirty ? porcelain.split('\n').slice(0, 8).join('\n') : '(still clean)'
   );
-  return { dirty, porcelain, waitedMs: Date.now() - start, polls };
+  return { dirty, headMoved, porcelain, waitedMs: Date.now() - start, polls };
 }
 
 const AUTOFIX_REVIEW_BODY_MAX_CHARS = parseInt(
@@ -815,6 +861,13 @@ async function runSinglePostReviewAutofix({
     prUrl,
   });
 
+  let preAgentHeadSha = '';
+  try {
+    preAgentHeadSha = await getHeadShaFull(repo);
+  } catch (e) {
+    logPost('post-review autofix: could not read HEAD before agent', e.stderr || e.message || String(e));
+  }
+
   let agentResult;
   try {
     agentResult = await runCursorCliAgent(prompt, { runId: autofixRunId, workspaceRoot: repo });
@@ -854,9 +907,9 @@ async function runSinglePostReviewAutofix({
     };
   }
 
-  const wait = await waitForDirtyWorkspace(repo);
-  if (!wait.dirty) {
-    logPost('post-review autofix: working tree still clean after agent', {
+  const wait = await waitForAgentGitActivity(repo, preAgentHeadSha || null);
+  if (!wait.dirty && !wait.headMoved) {
+    logPost('post-review autofix: no dirty tree and HEAD unchanged after agent', {
       waitedMs: wait.waitedMs,
       polls: wait.polls,
     });
@@ -864,7 +917,7 @@ async function runSinglePostReviewAutofix({
       ok: false,
       mergeBlocked: true,
       detail:
-        'Autofix finished but **git detected no file changes** after waiting — treat as failed for merge purposes.',
+        'Autofix finished but **git detected no new commits and no uncommitted changes** after waiting — treat as failed for merge purposes.',
       agentOutcome,
     };
   }
@@ -875,15 +928,24 @@ async function runSinglePostReviewAutofix({
     '**Title:** address automated PR review feedback',
   ].join('\n');
 
-  const commit = await tryCommit(repo, { userPrompt: syntheticPrompt });
-  logPost('post-review autofix: tryCommit', { ok: commit.ok, reason: commit.reason, sha: commit.sha });
-  if (!commit.ok) {
-    return {
-      ok: false,
-      mergeBlocked: true,
-      detail: `Autofix made edits but commit failed (${commit.reason}${commit.error ? `: ${commit.error}` : ''}).`,
-      agentOutcome,
-    };
+  /** @type {{ ok: boolean, sha?: string, message?: string, reason?: string, error?: string }} */
+  let commit;
+  if (wait.dirty) {
+    commit = await tryCommit(repo, { userPrompt: syntheticPrompt });
+    logPost('post-review autofix: tryCommit', { ok: commit.ok, reason: commit.reason, sha: commit.sha });
+    if (!commit.ok) {
+      return {
+        ok: false,
+        mergeBlocked: true,
+        detail: `Autofix made edits but commit failed (${commit.reason}${commit.error ? `: ${commit.error}` : ''}).`,
+        agentOutcome,
+      };
+    }
+  } else {
+    const sha = await getHeadShaShort(repo);
+    const message = await getLastCommitSubjectLine(repo);
+    commit = { ok: true, sha, message };
+    logPost('post-review autofix: agent already committed; skipping tryCommit', { sha, message });
   }
 
   if (!pushAfterCommitEnabled()) {
@@ -1177,15 +1239,16 @@ async function runPostCloseChangesDeepInfra({ issueBlock }) {
  * `CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS`. Override the post-close model with `CURSOR_POST_CLOSE_CHANGES_MODEL`.
  * Freeform `cursor …` runs do not enter this pipeline.
  * Disable push with `CURSOR_POST_RUN_PUSH=0`, or PR only with `CURSOR_POST_RUN_PR=0`.
- * @param {{ repo: string, userPrompt: string, agentRunOk: boolean, issueMode?: { number: number } | null }} opts
+ * @param {{ repo: string, userPrompt: string, agentRunOk: boolean, issueMode?: { number: number } | null, preAgentHeadSha?: string | null }} opts
  */
 export async function maybeCommitReviewEmail(opts) {
-  const { repo, userPrompt, agentRunOk, issueMode = null } = opts;
+  const { repo, userPrompt, agentRunOk, issueMode = null, preAgentHeadSha = null } = opts;
   logPost('start', {
     repo,
     postRunEnabled: postRunEnabled(),
     agentRunOk,
     issueMode: issueMode?.number ?? null,
+    preAgentHeadSha: preAgentHeadSha ? `${String(preAgentHeadSha).slice(0, 7)}…` : null,
     pollMs: POLL_MS,
     maxWaitMs: MAX_WAIT_MS,
   });
@@ -1205,13 +1268,21 @@ export async function maybeCommitReviewEmail(opts) {
     return { ran: false, note: '', skipReason: 'not_issue_mode' };
   }
 
-  const wait = await waitForDirtyWorkspace(repo);
-  if (!wait.dirty) {
-    logPost('skip: working tree still clean after wait', { waitedMs: wait.waitedMs, polls: wait.polls });
+  const wait = await waitForAgentGitActivity(repo, preAgentHeadSha);
+  if (!wait.dirty && !wait.headMoved) {
+    logPost('skip: no dirty tree and HEAD unchanged after wait', {
+      waitedMs: wait.waitedMs,
+      polls: wait.polls,
+    });
     return { ran: false, note: '', skipReason: 'clean_after_wait' };
   }
 
-  logPost('working tree dirty, committing', { waitedMs: wait.waitedMs, polls: wait.polls });
+  logPost('agent git activity detected', {
+    dirty: wait.dirty,
+    headMoved: wait.headMoved,
+    waitedMs: wait.waitedMs,
+    polls: wait.polls,
+  });
 
   let workBranch;
   try {
@@ -1226,8 +1297,20 @@ export async function maybeCommitReviewEmail(opts) {
     };
   }
 
-  const commit = await tryCommit(repo, { userPrompt });
-  logPost('tryCommit result', { ok: commit.ok, reason: commit.reason, sha: commit.sha });
+  /** @type {{ ok: boolean, sha?: string, message?: string, reason?: string, error?: string }} */
+  let commit;
+  if (wait.dirty) {
+    commit = await tryCommit(repo, { userPrompt });
+    logPost('tryCommit result', { ok: commit.ok, reason: commit.reason, sha: commit.sha });
+  } else {
+    const sha = await getHeadShaShort(repo);
+    const message = await getLastCommitSubjectLine(repo);
+    commit = { ok: true, sha, message };
+    logPost('skip tryCommit: working tree clean but HEAD moved (agent already committed)', {
+      sha,
+      message,
+    });
+  }
   const diffFull = await getDiffText(repo, commit.ok);
   if (!diffFull.trim()) {
     logPost('warning: dirty porcelain but empty diff text after commit attempt');
@@ -1414,7 +1497,13 @@ export async function maybeCommitReviewEmail(opts) {
 
   const parts = [];
   if (commit.ok) {
-    parts.push(`Committed ${commit.sha} on \`${workBranch.branchName}\`: ${commit.message}`);
+    if (!wait.dirty && wait.headMoved) {
+      parts.push(
+        `Agent already committed \`${commit.sha}\` on \`${workBranch.branchName}\`: ${commit.message}`
+      );
+    } else {
+      parts.push(`Committed ${commit.sha} on \`${workBranch.branchName}\`: ${commit.message}`);
+    }
     if (workBranch.didCheckoutNew) {
       parts.push('(Created a new branch so this did not commit directly to the default branch.)');
     }

--- a/whatsapp/agents/cursorPostRun.js
+++ b/whatsapp/agents/cursorPostRun.js
@@ -64,9 +64,15 @@ pre.summary { white-space: pre-wrap; font-size: 0.95rem; margin: 0; }
 </html>`;
 }
 
-/** Poll after the agent process exits — writes may not be visible to git immediately. */
-const POLL_MS = parseInt(process.env.CURSOR_POST_RUN_POLL_MS || '250', 10);
-const MAX_WAIT_MS = parseInt(process.env.CURSOR_POST_RUN_MAX_WAIT_MS || '8000', 10);
+/** Poll after the agent process exits — writes may not be visible to git immediately. Read per wait so tests/env can tune without reloading the module. */
+function readPostRunGitWaitSettings() {
+  const pollMs = parseInt(process.env.CURSOR_POST_RUN_POLL_MS || '250', 10);
+  const maxWaitMs = parseInt(process.env.CURSOR_POST_RUN_MAX_WAIT_MS || '8000', 10);
+  return {
+    pollMs: Number.isFinite(pollMs) && pollMs >= 0 ? pollMs : 250,
+    maxWaitMs: Number.isFinite(maxWaitMs) && maxWaitMs > 0 ? maxWaitMs : 8000,
+  };
+}
 
 function postRunEnabled() {
   // Only set CURSOR_POST_RUN=0 in .env to disable. If unset or commented out, post-run is ON.
@@ -756,16 +762,20 @@ export async function getRepoHeadShaFull(repo) {
 /**
  * Wait until uncommitted changes appear **or** `HEAD` differs from `preAgentHeadSha` (agent committed).
  * When `preAgentHeadSha` is omitted, only porcelain (dirty) is considered — legacy behaviour.
+ * Each poll runs `git status --porcelain` and, when tracking head, `git rev-parse HEAD` — intentional
+ * so we notice a new commit as soon as it lands (cheap for the short bounded wait); do not “optimize”
+ * away the per-poll `HEAD` read without tests.
  * @param {string} repo
  * @param {string | null | undefined} preAgentHeadSha
  * @returns {Promise<{ dirty: boolean, headMoved: boolean, porcelain: string, waitedMs: number, polls: number }>}
  */
 async function waitForAgentGitActivity(repo, preAgentHeadSha) {
+  const { pollMs, maxWaitMs } = readPostRunGitWaitSettings();
   const pre = typeof preAgentHeadSha === 'string' ? preAgentHeadSha.trim() : '';
   const trackHead = pre.length > 0;
   const start = Date.now();
   let polls = 0;
-  while (Date.now() - start < MAX_WAIT_MS) {
+  while (Date.now() - start < maxWaitMs) {
     polls++;
     let porcelain;
     let headNow = '';
@@ -792,7 +802,7 @@ async function waitForAgentGitActivity(repo, preAgentHeadSha) {
         polls,
       };
     }
-    await new Promise((r) => setTimeout(r, POLL_MS));
+    await new Promise((r) => setTimeout(r, pollMs));
   }
   let porcelain = '';
   let headNow = '';
@@ -806,7 +816,7 @@ async function waitForAgentGitActivity(repo, preAgentHeadSha) {
   const dirty = Boolean(porcelain);
   const headMoved = trackHead && headNow !== pre;
   logPost(
-    `timeout ${MAX_WAIT_MS}ms after ${polls} polls dirty=${dirty} headMoved=${headMoved}`,
+    `timeout ${maxWaitMs}ms after ${polls} polls dirty=${dirty} headMoved=${headMoved}`,
     dirty ? porcelain.split('\n').slice(0, 8).join('\n') : '(still clean)'
   );
   return { dirty, headMoved, porcelain, waitedMs: Date.now() - start, polls };
@@ -1021,6 +1031,46 @@ async function getDiffText(repo, commitOk) {
   if (staged.trim()) return staged;
   const { stdout: unstaged } = await execGit(['diff', '--no-color'], repo);
   return unstaged || '';
+}
+
+/**
+ * Diff text for the post-run LLM review (and empty-diff guard).
+ * When the agent left a **clean** tree but **moved `HEAD`** (committed), `git show HEAD` only covers the
+ * tip commit; we prefer the PR-style merge-base range against `prBase`, then the exact agent span
+ * `preAgentHeadSha...HEAD`, then `git show HEAD` as a last resort.
+ * @param {string} repo
+ * @param {{ prBase: string, branchName?: string }} workBranch
+ * @param {{ dirty: boolean, headMoved: boolean }} wait
+ * @param {string | null | undefined} preAgentHeadSha
+ * @param {boolean} commitOk
+ * @returns {Promise<string>}
+ */
+export async function getPostRunReviewDiffText(repo, workBranch, wait, preAgentHeadSha, commitOk) {
+  const cleanCommitted = !wait.dirty && wait.headMoved;
+  if (!cleanCommitted) {
+    return getDiffText(repo, commitOk);
+  }
+  const prBase = String(workBranch?.prBase || 'main').trim() || 'main';
+  const pre =
+    typeof preAgentHeadSha === 'string' && preAgentHeadSha.trim() ? preAgentHeadSha.trim() : '';
+  /** @type {string[]} */
+  const ranges = [];
+  if (prBase) ranges.push(`${prBase}...HEAD`);
+  if (pre) ranges.push(`${pre}...HEAD`);
+  for (const range of ranges) {
+    try {
+      const { stdout } = await execGit(['diff', '--no-color', range], repo);
+      if (stdout && stdout.trim()) return stdout;
+    } catch {
+      /* unknown ref or invalid range — try next */
+    }
+  }
+  try {
+    const { stdout } = await execGit(['show', '--no-color', '--pretty=medium', 'HEAD'], repo);
+    return stdout || '';
+  } catch {
+    return '';
+  }
 }
 
 async function runLlmReview(diffForLlm, userPrompt) {
@@ -1243,14 +1293,15 @@ async function runPostCloseChangesDeepInfra({ issueBlock }) {
  */
 export async function maybeCommitReviewEmail(opts) {
   const { repo, userPrompt, agentRunOk, issueMode = null, preAgentHeadSha = null } = opts;
+  const { pollMs, maxWaitMs } = readPostRunGitWaitSettings();
   logPost('start', {
     repo,
     postRunEnabled: postRunEnabled(),
     agentRunOk,
     issueMode: issueMode?.number ?? null,
     preAgentHeadSha: preAgentHeadSha ? `${String(preAgentHeadSha).slice(0, 7)}…` : null,
-    pollMs: POLL_MS,
-    maxWaitMs: MAX_WAIT_MS,
+    pollMs,
+    maxWaitMs,
   });
 
   if (!postRunEnabled()) {
@@ -1311,12 +1362,12 @@ export async function maybeCommitReviewEmail(opts) {
       message,
     });
   }
-  const diffFull = await getDiffText(repo, commit.ok);
+  const diffFull = await getPostRunReviewDiffText(repo, workBranch, wait, preAgentHeadSha, commit.ok);
   if (!diffFull.trim()) {
-    logPost('warning: dirty porcelain but empty diff text after commit attempt');
+    logPost('warning: empty diff text after commit / range resolution');
     return {
       ran: true,
-      note: 'Working tree was dirty but no diff text could be read after commit attempt.',
+      note: 'Git activity was detected but no diff text could be read for review (try a manual push/PR).',
       skipReason: 'empty_diff',
     };
   }


### PR DESCRIPTION
Fixes #35

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-35-cursorpostrun-skips-push-pr-review-when-agent-al`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #35

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/35
**State:** OPEN
**Title:** cursorPostRun skips push/PR/review when agent already committed (clean working tree)

## Body
## Bug
When a cron-spawned `cursor issue:<n>` run finishes with the repo **clean** (because the agent already created a commit), the post-run pipeline exits early and **never pushes the branch, never opens a PR, and never runs/posts the LLM review**.

This matches log output like:

```
[cursorPostRun] poll #2 (261ms) dirty=false (clean)
...
[cursorPostRun] timeout 8000ms after 32 polls dirty=false (still clean)
[cursorPostRun] skip: working tree still clean after wait { waitedMs: 8230, polls: 32 }
```

## Expected
Even if the working tree is clean, if the run produced **new commits** (or the branch is ahead of the base / has no upstream yet), post-run should still:
- push `HEAD` to `origin`
- create/reuse a PR
- run the LLM review and post the PR comment

## Actual
Post-run is gated solely on uncommitted changes:
- `waitForDirtyWorkspace()` checks `git status --porcelain`
- `maybeCommitReviewEmail()` returns `skipReason: clean_after_wait` when porcelain stays empty

Relevant code (current main):
- `whatsapp/agents/cursorPostRun.js`: `waitForDirtyWorkspace()` and the early return in `maybeCommitReviewEmail()` after calling it (logs "skip: working tree still clean after wait").

## Why this happens
A run that already did `git commit` leaves the working tree clean, so `git status --porcelain` never becomes non-empty. The pipeline interprets that as “no work happened” even though `HEAD` moved.

## Suggested fix
Change the gating from “dirty files exist” to “either dirty **or** new commits exist”. Options:
- Capture `preHeadSha = git rev-parse HEAD` before running the agent in `runCursorAgentWithPost()` and pass it to `maybeCommitReviewEmail()`. Poll until either porcelain is non-empty **or** `HEAD` differs from `preHeadSha`.
- Or, when porcelain is empty, compute whether `HEAD` is ahead of base (e.g. `git rev-list --count origin/<defaultBranch>..HEAD`) and proceed with push/PR/review when ahead > 0.

In the “clean but new commits” case, skip `tryCommit()` and use `git show HEAD` / `git diff <base>...HEAD` for review content, then push + PR flow.

## Notes
There’s a similar pattern in `runSinglePostReviewAutofix()` which also treats “clean after agent” as failure; if that agent ever commits, it will be misclassified too.