### PR TITLE
fix: Post-close summary email often not sent: issue-close pollin… (#36)

### DIFF
--- a/whatsapp/agents/cursorPostRun.js
+++ b/whatsapp/agents/cursorPostRun.js
@@ -106,13 +106,21 @@ function prAutoMergeAfterReviewEnabled() {
   return true;
 }
 
-/** Poll interval while waiting for the linked GitHub issue to close after auto-merge is queued. */
-const ISSUE_CLOSE_POLL_MS = parseInt(process.env.CURSOR_POST_RUN_ISSUE_CLOSE_POLL_MS || '4000', 10);
-/** Max time to wait for the issue to show `CLOSED` after auto-merge is enabled (bounded). */
-const ISSUE_CLOSE_MAX_WAIT_MS = parseInt(
-  process.env.CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS || '180000',
-  10
-);
+/**
+ * Issue-close poll tuning (read per wait so tests/env can tune without reloading the module).
+ * Default max wait is 30 minutes — short CI windows (formerly 3 min) caused post-close emails to be skipped when merges lagged (GitHub #36).
+ */
+function readIssueCloseWaitSettings() {
+  const pollMs = parseInt(process.env.CURSOR_POST_RUN_ISSUE_CLOSE_POLL_MS || '4000', 10);
+  const maxWaitMs = parseInt(
+    process.env.CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS || '1800000',
+    10
+  );
+  return {
+    pollMs: Number.isFinite(pollMs) && pollMs >= 0 ? pollMs : 4000,
+    maxWaitMs: Number.isFinite(maxWaitMs) && maxWaitMs > 0 ? maxWaitMs : 1_800_000,
+  };
+}
 
 /** DeepInfra model for post-close “changes made” email (GitHub issue #14). */
 const POST_CLOSE_CHANGES_MODEL =
@@ -503,8 +511,9 @@ async function tryGhIssueViewDetails(repo, issueNumber) {
  * @param {{ maxWaitMs?: number, pollMs?: number }} [opts]
  */
 async function waitForGithubIssueClosed(repo, issueNumber, opts = {}) {
-  const maxWaitMs = Number.isFinite(opts.maxWaitMs) ? opts.maxWaitMs : ISSUE_CLOSE_MAX_WAIT_MS;
-  const pollMs = Number.isFinite(opts.pollMs) ? opts.pollMs : ISSUE_CLOSE_POLL_MS;
+  const defaults = readIssueCloseWaitSettings();
+  const maxWaitMs = Number.isFinite(opts.maxWaitMs) ? opts.maxWaitMs : defaults.maxWaitMs;
+  const pollMs = Number.isFinite(opts.pollMs) ? opts.pollMs : defaults.pollMs;
   return pollGithubIssueClosedOrTimeout({
     maxWaitMs,
     pollMs,
@@ -1286,7 +1295,7 @@ async function runPostCloseChangesDeepInfra({ issueBlock }) {
  * When the issue is confirmed **CLOSED**, sends a separate **“changes made”** email (DeepInfra
  * `meta-llama/Meta-Llama-3-8B-Instruct` by default) to `CURSOR_REVIEW_EMAIL_TO` via Gmail SMTP (issue #14).
  * Disable auto-merge with `CURSOR_POST_RUN_PR_AUTO_MERGE=0`. Tune wait with `CURSOR_POST_RUN_ISSUE_CLOSE_POLL_MS` /
- * `CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS`. Override the post-close model with `CURSOR_POST_CLOSE_CHANGES_MODEL`.
+ * `CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS` (default 30 minutes). Override the post-close model with `CURSOR_POST_CLOSE_CHANGES_MODEL`.
  * Freeform `cursor …` runs do not enter this pipeline.
  * Disable push with `CURSOR_POST_RUN_PUSH=0`, or PR only with `CURSOR_POST_RUN_PR=0`.
  * @param {{ repo: string, userPrompt: string, agentRunOk: boolean, issueMode?: { number: number } | null, preAgentHeadSha?: string | null }} opts
@@ -1616,7 +1625,7 @@ export async function maybeCommitReviewEmail(opts) {
           );
         } else if (issueCloseWait?.timedOut) {
           parts.push(
-            `**Merge pending / issue not yet closed:** auto-merge (squash) was requested for the PR, but issue **#${issueNum}** is still **not closed** after waiting (bounded poll). The merge may still complete in the background once checks and branch rules allow.`
+            `**Merge pending / issue not yet closed:** auto-merge (squash) was requested for the PR, but issue **#${issueNum}** is still **not closed** after waiting (bounded poll). The merge may still complete in the background once checks and branch rules allow. **Post-close summary email** was not sent for the same reason (issue never reached CLOSED within \`CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS\`). There is no follow-up send after this run ends; raise the wait time or send the summary manually if CI is slow.`
           );
         }
       } else {


### PR DESCRIPTION
Fixes #36

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-36-post-close-summary-email-often-not-sent-issue-cl`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #36

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/36
**State:** OPEN
**Title:** Post-close summary email often not sent: issue-close polling times out (default 3min)

## Body
## Summary
When running the `cursor issue:<n>` workflow, the **post-close “changes summary” email** is only attempted if the linked GitHub issue is observed **CLOSED within a bounded poll window** after auto-merge is queued.

With the current defaults, that poll window is **3 minutes** (`CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS` defaults to `180000`). In real usage, PR checks / required CI often take longer than 3 minutes, so the poll frequently times out and the email is **never sent at all**. This matches the reported behavior: “works sometimes”, but “most often than not” no email arrives.

DeepInfra errors may still happen, but they are **not required** to reproduce the missing-email behavior.

## Where in code
- `whatsapp/agents/cursorPostRun.js`
  - `ISSUE_CLOSE_MAX_WAIT_MS` default: `CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS || '180000'`
  - Email send happens only inside `if (issueCloseWait?.closed) { ... }`

## Expected
If auto-merge is enabled and the PR eventually merges (therefore the linked issue eventually closes), the bot should **eventually** send the post-close summary email (or clearly state it won’t).

## Actual
If the issue does not reach `CLOSED` within the poll timeout, the run ends with no email.
- If the issue closes later (after the timeout), there is currently **no follow-up mechanism** to send the email.

## Why it looks intermittent
- If merges/checks are fast (or there are no required checks), the issue may close quickly → email is sent.
- If checks take longer than ~3 minutes → the poll times out → no email.

## Repro (likely)
1. Run `cursor issue:<n>` that creates a PR and queues auto-merge.
2. Ensure the repo has required checks that take > 3 minutes.
3. Observe that the WhatsApp note may say merge is pending / issue not yet closed.
4. After the PR merges and the issue later closes, **no email** is sent.

## Suggested fixes
- **Short-term / config**: increase `CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS` to something that matches CI reality (e.g. 20–60 minutes).
- **Robust**: persist a “pending post-close email” job when auto-merge is queued, and have a background task (startup/cron) poll until closure and send the email.
- **UX**: when the poll times out, explicitly report “email not sent because issue did not close within the wait window” (currently there’s a merge-pending message but no explicit email expectation).

## Notes on DeepInfra
The email body generation uses DeepInfra (`runPostCloseChangesDeepInfra`). If DeepInfra fails, the system can report that as a `deepinfra` step failure. However, even with DeepInfra working, the email is skipped when the issue-close poll times out.

## Context
- Repo: alexisNorthcoders/WhatsappBot
- Commit: 2679d03ab196339af09e2579515dc5f9d6a7cbd8
- OS: linux 6.17.0-19-generic