### PR TITLE
fix: Summarize: shared URL safety + fetch caps module (#41)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.5",
         "ejs": "^3.1.10",
         "express": "^4.19.2",
+        "ipaddr.js": "^2.4.0",
         "node-media-server": "^2.7.0",
         "nodemailer": "^8.0.3",
         "openai": "^4.53.2",
@@ -2126,11 +2127,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-typedarray": {
@@ -2683,6 +2685,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dotenv": "^16.4.5",
     "ejs": "^3.1.10",
     "express": "^4.19.2",
+    "ipaddr.js": "^2.4.0",
     "node-media-server": "^2.7.0",
     "nodemailer": "^8.0.3",
     "openai": "^4.53.2",

--- a/test/urlFetchSafety.test.js
+++ b/test/urlFetchSafety.test.js
@@ -1,0 +1,139 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  botFetch,
+  buildBotFetchRequestInit,
+  getBotFetchTimeoutMs,
+  isUrlAllowedForFetch,
+  readResponseBodyBuffer,
+} from '../whatsapp/utils/urlFetchSafety.js';
+
+describe('isUrlAllowedForFetch', () => {
+  it('allows public https URLs', () => {
+    assert.equal(isUrlAllowedForFetch('https://example.com/path?q=1'), true);
+    assert.equal(isUrlAllowedForFetch('http://8.8.8.8/'), true);
+  });
+
+  it('denies non-http(s) schemes', () => {
+    assert.equal(isUrlAllowedForFetch('file:///etc/passwd'), false);
+    assert.equal(isUrlAllowedForFetch('ftp://example.com/'), false);
+    assert.equal(isUrlAllowedForFetch('javascript:alert(1)'), false);
+  });
+
+  it('denies credentials in URL', () => {
+    assert.equal(isUrlAllowedForFetch('https://user:pass@example.com/'), false);
+    assert.equal(isUrlAllowedForFetch('http://user@example.com/'), false);
+  });
+
+  it('denies localhost and obvious local hostnames', () => {
+    assert.equal(isUrlAllowedForFetch('http://localhost/'), false);
+    assert.equal(isUrlAllowedForFetch('http://api.localhost/'), false);
+    assert.equal(isUrlAllowedForFetch('http://mybox.local/'), false);
+  });
+
+  it('denies private and loopback IPv4 literals', () => {
+    assert.equal(isUrlAllowedForFetch('http://127.0.0.1/'), false);
+    assert.equal(isUrlAllowedForFetch('http://10.0.0.1/'), false);
+    assert.equal(isUrlAllowedForFetch('http://192.168.1.2/'), false);
+    assert.equal(isUrlAllowedForFetch('http://172.17.0.1/'), false);
+    assert.equal(isUrlAllowedForFetch('http://169.254.1.1/'), false);
+    assert.equal(isUrlAllowedForFetch('http://0.0.0.0/'), false);
+  });
+
+  it('denies IPv6 loopback, ULA, link-local, and IPv4-mapped private', () => {
+    assert.equal(isUrlAllowedForFetch('http://[::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[fe80::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[fc00::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[fd12:3456::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[::ffff:192.168.0.1]/'), false);
+  });
+
+  it('rejects malformed URLs', () => {
+    assert.equal(isUrlAllowedForFetch('not a url'), false);
+    assert.equal(isUrlAllowedForFetch(''), false);
+  });
+});
+
+describe('getBotFetchTimeoutMs (env)', () => {
+  const prev = process.env.BOT_FETCH_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BOT_FETCH_TIMEOUT_MS;
+    else process.env.BOT_FETCH_TIMEOUT_MS = prev;
+  });
+
+  it('reads BOT_FETCH_TIMEOUT_MS when set', () => {
+    process.env.BOT_FETCH_TIMEOUT_MS = '12345';
+    assert.equal(getBotFetchTimeoutMs(), 12345);
+  });
+});
+
+describe('readResponseBodyBuffer', () => {
+  it('throws when Content-Length exceeds cap', async () => {
+    const res = new Response('', {
+      headers: { 'content-length': String(50 * 1024 * 1024) },
+    });
+    await assert.rejects(() => readResponseBodyBuffer(res, 1024), /too large/);
+  });
+
+  it('returns buffer when within cap', async () => {
+    const res = new Response('hello', {
+      headers: { 'content-length': '5' },
+    });
+    const buf = await readResponseBodyBuffer(res, 1024);
+    assert.equal(new TextDecoder().decode(buf), 'hello');
+  });
+});
+
+describe('buildBotFetchRequestInit', () => {
+  it('sets manual redirect and User-Agent', () => {
+    const init = buildBotFetchRequestInit({
+      userAgent: 'TestUA/1',
+    });
+    assert.equal(init.redirect, 'manual');
+    assert.ok(init.signal);
+    assert.equal(init.headers['User-Agent'], 'TestUA/1');
+    assert.ok(String(init.headers.Accept).includes('text/html'));
+  });
+});
+
+describe('botFetch redirect validation', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('rejects redirect to disallowed host', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'http://127.0.0.1/secret' },
+      });
+
+    await assert.rejects(
+      () => botFetch('https://example.com/start', buildBotFetchRequestInit()),
+      /not allowed|Redirect target/i,
+    );
+  });
+
+  it('follows allowed redirect then returns final response', async () => {
+    let n = 0;
+    globalThis.fetch = async (url) => {
+      n += 1;
+      if (n === 1) {
+        assert.equal(String(url), 'https://example.com/a');
+        return new Response(null, {
+          status: 302,
+          headers: { Location: '/b' },
+        });
+      }
+      assert.equal(String(url), 'https://example.com/b');
+      return new Response('done', { status: 200 });
+    };
+
+    const res = await botFetch('https://example.com/a', buildBotFetchRequestInit());
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'done');
+  });
+});

--- a/test/urlFetchSafety.test.js
+++ b/test/urlFetchSafety.test.js
@@ -3,6 +3,9 @@ import assert from 'node:assert/strict';
 import {
   botFetch,
   buildBotFetchRequestInit,
+  getBotFetchMaxHtmlChars,
+  getBotFetchMaxRedirects,
+  getBotFetchMaxResponseBytes,
   getBotFetchTimeoutMs,
   isUrlAllowedForFetch,
   readResponseBodyBuffer,
@@ -38,14 +41,20 @@ describe('isUrlAllowedForFetch', () => {
     assert.equal(isUrlAllowedForFetch('http://172.17.0.1/'), false);
     assert.equal(isUrlAllowedForFetch('http://169.254.1.1/'), false);
     assert.equal(isUrlAllowedForFetch('http://0.0.0.0/'), false);
+    assert.equal(isUrlAllowedForFetch('http://100.64.0.1/'), false);
   });
 
-  it('denies IPv6 loopback, ULA, link-local, and IPv4-mapped private', () => {
+  it('denies IPv6 loopback, ULA, link-local, reserved, and IPv4-mapped private', () => {
     assert.equal(isUrlAllowedForFetch('http://[::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[0:0:0:0:0:0:0:1]/'), false);
     assert.equal(isUrlAllowedForFetch('http://[fe80::1]/'), false);
     assert.equal(isUrlAllowedForFetch('http://[fc00::1]/'), false);
     assert.equal(isUrlAllowedForFetch('http://[fd12:3456::1]/'), false);
     assert.equal(isUrlAllowedForFetch('http://[::ffff:192.168.0.1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[::ffff:127.0.0.1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[fec0::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[2001:db8::1]/'), false);
+    assert.equal(isUrlAllowedForFetch('http://[::]/'), false);
   });
 
   it('rejects malformed URLs', () => {
@@ -68,6 +77,48 @@ describe('getBotFetchTimeoutMs (env)', () => {
   });
 });
 
+describe('getBotFetchMaxRedirects (env)', () => {
+  const prev = process.env.BOT_FETCH_MAX_REDIRECTS;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BOT_FETCH_MAX_REDIRECTS;
+    else process.env.BOT_FETCH_MAX_REDIRECTS = prev;
+  });
+
+  it('reads BOT_FETCH_MAX_REDIRECTS when set', () => {
+    process.env.BOT_FETCH_MAX_REDIRECTS = '3';
+    assert.equal(getBotFetchMaxRedirects(), 3);
+  });
+});
+
+describe('getBotFetchMaxResponseBytes (env)', () => {
+  const prev = process.env.BOT_FETCH_MAX_RESPONSE_BYTES;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.BOT_FETCH_MAX_RESPONSE_BYTES;
+    else process.env.BOT_FETCH_MAX_RESPONSE_BYTES = prev;
+  });
+
+  it('reads BOT_FETCH_MAX_RESPONSE_BYTES when set', () => {
+    process.env.BOT_FETCH_MAX_RESPONSE_BYTES = '2048';
+    assert.equal(getBotFetchMaxResponseBytes(), 2048);
+  });
+});
+
+describe('getBotFetchMaxHtmlChars (env)', () => {
+  const prev = process.env.JOPLIN_FETCH_MAX_HTML_CHARS;
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.JOPLIN_FETCH_MAX_HTML_CHARS;
+    else process.env.JOPLIN_FETCH_MAX_HTML_CHARS = prev;
+  });
+
+  it('reads JOPLIN_FETCH_MAX_HTML_CHARS when set', () => {
+    process.env.JOPLIN_FETCH_MAX_HTML_CHARS = '999';
+    assert.equal(getBotFetchMaxHtmlChars(), 999);
+  });
+});
+
 describe('readResponseBodyBuffer', () => {
   it('throws when Content-Length exceeds cap', async () => {
     const res = new Response('', {
@@ -82,6 +133,19 @@ describe('readResponseBodyBuffer', () => {
     });
     const buf = await readResponseBodyBuffer(res, 1024);
     assert.equal(new TextDecoder().decode(buf), 'hello');
+  });
+
+  it('aborts streaming read when body grows past cap without Content-Length', async () => {
+    const enc = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(enc.encode('a'.repeat(600)));
+        controller.enqueue(enc.encode('b'.repeat(600)));
+        controller.close();
+      },
+    });
+    const res = new Response(stream);
+    await assert.rejects(() => readResponseBodyBuffer(res, 1000), /too large/);
   });
 });
 
@@ -113,7 +177,7 @@ describe('botFetch redirect validation', () => {
 
     await assert.rejects(
       () => botFetch('https://example.com/start', buildBotFetchRequestInit()),
-      /not allowed|Redirect target/i,
+      /Redirect target is not allowed/,
     );
   });
 
@@ -135,5 +199,63 @@ describe('botFetch redirect validation', () => {
     const res = await botFetch('https://example.com/a', buildBotFetchRequestInit());
     assert.equal(res.status, 200);
     assert.equal(await res.text(), 'done');
+  });
+
+  it('throws when redirect limit is exhausted', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://example.com/next' },
+      });
+
+    await assert.rejects(
+      () =>
+        botFetch('https://example.com/start', buildBotFetchRequestInit({ timeoutMs: 5000 })),
+      /Too many redirects/,
+    );
+  });
+
+  it('throws on empty Location', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { Location: '   ' },
+      });
+
+    await assert.rejects(
+      () => botFetch('https://example.com/start', buildBotFetchRequestInit()),
+      /missing Location/i,
+    );
+  });
+
+  it('throws on malformed Location URL', async () => {
+    globalThis.fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'http://%ZZ' },
+      });
+
+    await assert.rejects(
+      () => botFetch('https://example.com/start', buildBotFetchRequestInit()),
+      /Invalid redirect Location/,
+    );
+  });
+
+  it('passes a fresh RequestInit (signal) on each redirect hop', async () => {
+    const signals = [];
+    globalThis.fetch = async (_url, init) => {
+      signals.push(init.signal);
+      if (signals.length === 1) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: '/two' },
+        });
+      }
+      return new Response('ok', { status: 200 });
+    };
+
+    await botFetch('https://example.com/one', buildBotFetchRequestInit());
+    assert.equal(signals.length, 2);
+    assert.notEqual(signals[0], signals[1]);
   });
 });

--- a/whatsapp/agents/joplinAgent.js
+++ b/whatsapp/agents/joplinAgent.js
@@ -5,6 +5,7 @@ import { openaiChatTokenOpts } from '../../models/models.js';
 import {
   botFetch,
   buildBotFetchRequestInit,
+  getBotFetchMaxHtmlChars,
   isUrlAllowedForFetch,
   readResponseBodyBuffer,
 } from '../utils/urlFetchSafety.js';
@@ -56,12 +57,6 @@ const KEYWORD_PATTERN =
   /\b(note|notes|notepad|joplin|notebook|notebooks)\b|\b(save|add|write)\s+(a\s+)?note\b|\b(list|show|search|find|get|open|delete|remove|update|edit)\b.*\bnote|\b(fetch|save|archive|capture|store)\s+(the\s+)?(page|url|web|html|site|webpage)\b|\bhttps?:\/\/\S+.*\b(joplin|note|save|archive|page|html)\b|\b(joplin|note|save)\b.*\bhttps?:\/\//i;
 
 const FETCH_USER_AGENT = 'WhatsappBot-JoplinAgent/1.0';
-const DEFAULT_MAX_FETCH_CHARS = 500_000;
-
-function maxFetchChars() {
-  const n = parseInt(process.env.JOPLIN_FETCH_MAX_HTML_CHARS || String(DEFAULT_MAX_FETCH_CHARS), 10);
-  return Number.isFinite(n) && n > 0 ? Math.min(n, 2_000_000) : DEFAULT_MAX_FETCH_CHARS;
-}
 
 function markdownFence(lang, content) {
   const inner = String(content);
@@ -74,7 +69,7 @@ function markdownFence(lang, content) {
 }
 
 async function fetchUrlBodyForNote(url) {
-  const maxChars = maxFetchChars();
+  const maxChars = getBotFetchMaxHtmlChars();
   const res = await botFetch(
     url,
     buildBotFetchRequestInit({

--- a/whatsapp/agents/joplinAgent.js
+++ b/whatsapp/agents/joplinAgent.js
@@ -2,6 +2,12 @@ import dotenv from 'dotenv';
 import OpenAI from 'openai';
 import joplinAPI, { WHATSAPP_BOT_NOTEBOOK } from '../../joplin/index.js';
 import { openaiChatTokenOpts } from '../../models/models.js';
+import {
+  botFetch,
+  buildBotFetchRequestInit,
+  isUrlAllowedForFetch,
+  readResponseBodyBuffer,
+} from '../utils/urlFetchSafety.js';
 import { logAgentInvocation, addCompletionUsage } from './agentUsageLog.js';
 
 dotenv.config();
@@ -57,32 +63,6 @@ function maxFetchChars() {
   return Number.isFinite(n) && n > 0 ? Math.min(n, 2_000_000) : DEFAULT_MAX_FETCH_CHARS;
 }
 
-/** Block obvious SSRF targets (private/local); http(s) only. */
-function isUrlAllowedForFetch(urlStr) {
-  let u;
-  try {
-    u = new URL(urlStr.trim());
-  } catch {
-    return false;
-  }
-  if (u.username || u.password) return false;
-  if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
-  const host = u.hostname.toLowerCase();
-  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) return false;
-  if (host === '::1') return false;
-  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (ipv4) {
-    const a = Number(ipv4[1]);
-    const b = Number(ipv4[2]);
-    if (a === 10) return false;
-    if (a === 127 || a === 0) return false;
-    if (a === 192 && b === 168) return false;
-    if (a === 169 && b === 254) return false;
-    if (a === 172 && b >= 16 && b <= 31) return false;
-  }
-  return true;
-}
-
 function markdownFence(lang, content) {
   const inner = String(content);
   let longest = 0;
@@ -95,13 +75,14 @@ function markdownFence(lang, content) {
 
 async function fetchUrlBodyForNote(url) {
   const maxChars = maxFetchChars();
-  const res = await fetch(url, {
-    headers: { Accept: 'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.8', 'User-Agent': FETCH_USER_AGENT },
-    redirect: 'follow',
-    signal: AbortSignal.timeout(45_000),
-  });
+  const res = await botFetch(
+    url,
+    buildBotFetchRequestInit({
+      userAgent: FETCH_USER_AGENT,
+    }),
+  );
   const ct = res.headers.get('content-type') || '';
-  const buf = await res.arrayBuffer();
+  const buf = await readResponseBodyBuffer(res);
   const dec = new TextDecoder('utf-8');
   let text = dec.decode(buf);
   const fullLen = text.length;

--- a/whatsapp/utils/urlFetchSafety.js
+++ b/whatsapp/utils/urlFetchSafety.js
@@ -1,0 +1,229 @@
+/**
+ * Shared guardrails for accepting user-provided URLs and fetching them in-process (SSRF reduction).
+ */
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+export const DEFAULT_BOT_FETCH_TIMEOUT_MS = 45_000;
+export const DEFAULT_BOT_FETCH_MAX_REDIRECTS = 10;
+/** Hard cap on response body bytes after redirects (separate from character truncation of decoded text). */
+export const DEFAULT_BOT_FETCH_MAX_RESPONSE_BYTES = 12 * 1024 * 1024;
+
+function parsePositiveInt(value, fallback) {
+  const n = parseInt(String(value), 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function getBotFetchTimeoutMs() {
+  return Math.min(
+    parsePositiveInt(process.env.BOT_FETCH_TIMEOUT_MS, DEFAULT_BOT_FETCH_TIMEOUT_MS),
+    600_000,
+  );
+}
+
+export function getBotFetchMaxRedirects() {
+  return Math.min(
+    parsePositiveInt(process.env.BOT_FETCH_MAX_REDIRECTS, DEFAULT_BOT_FETCH_MAX_REDIRECTS),
+    20,
+  );
+}
+
+export function getBotFetchMaxResponseBytes() {
+  return Math.min(
+    parsePositiveInt(process.env.BOT_FETCH_MAX_RESPONSE_BYTES, DEFAULT_BOT_FETCH_MAX_RESPONSE_BYTES),
+    64 * 1024 * 1024,
+  );
+}
+
+/**
+ * Default numeric limits for bot HTTP fetches (timeouts, redirects, raw body size).
+ */
+export function getBotFetchLimits() {
+  return {
+    timeoutMs: getBotFetchTimeoutMs(),
+    maxRedirects: getBotFetchMaxRedirects(),
+    maxResponseBytes: getBotFetchMaxResponseBytes(),
+  };
+}
+
+export const DEFAULT_BOT_FETCH_ACCEPT =
+  'text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.8';
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.userAgent]
+ * @param {string} [opts.accept]
+ * @param {AbortSignal} [opts.signal] Combined with timeout via AbortSignal.any when available.
+ */
+export function buildBotFetchSignal(timeoutMs, userSignal) {
+  const t = AbortSignal.timeout(timeoutMs);
+  if (!userSignal) return t;
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([t, userSignal]);
+  }
+  return t;
+}
+
+/**
+ * Request init for a single hop (caller follows redirects). Uses `redirect: 'manual'`.
+ * @param {object} [opts]
+ * @param {string} [opts.userAgent]
+ * @param {string} [opts.accept]
+ * @param {Record<string, string>} [opts.headers] Merged over Accept and User-Agent if those keys omitted.
+ * @param {number} [opts.timeoutMs]
+ * @param {AbortSignal} [opts.signal]
+ */
+export function buildBotFetchRequestInit(opts = {}) {
+  const limits = getBotFetchLimits();
+  const timeoutMs = opts.timeoutMs ?? limits.timeoutMs;
+  const ua = opts.userAgent ?? 'WhatsappBot/1.0';
+  const accept = opts.accept ?? DEFAULT_BOT_FETCH_ACCEPT;
+  const headers = { Accept: accept, 'User-Agent': ua, ...opts.headers };
+  return {
+    redirect: 'manual',
+    signal: buildBotFetchSignal(timeoutMs, opts.signal),
+    headers,
+  };
+}
+
+function isBlockedIPv4Octets(a, b) {
+  if (a === 10) return true;
+  if (a === 127 || a === 0) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  return false;
+}
+
+/** @param {string} host lowercased, dotted IPv4 or null */
+function isBlockedIPv4Literal(host) {
+  if (!host) return false;
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!ipv4) return false;
+  const nums = [Number(ipv4[1]), Number(ipv4[2]), Number(ipv4[3]), Number(ipv4[4])];
+  if (nums.some((n) => n > 255 || !Number.isFinite(n))) return false;
+  return isBlockedIPv4Octets(nums[0], nums[1]);
+}
+
+/** @param {string} tail IPv4-mapped tail after the `::ffff:` prefix */
+function ipv4MappedTailToOctets(tail) {
+  const t = tail.toLowerCase();
+  if (t.includes('.')) {
+    const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(t);
+    if (!m) return null;
+    const nums = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+    return nums.every((n) => n <= 255 && Number.isFinite(n)) ? nums : null;
+  }
+  const parts = t.split(':').filter(Boolean);
+  if (parts.length === 2) {
+    const hi = parseInt(parts[0], 16);
+    const lo = parseInt(parts[1], 16);
+    if (!Number.isFinite(hi) || !Number.isFinite(lo)) return null;
+    return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff];
+  }
+  if (parts.length === 1) {
+    const v = parseInt(parts[0], 16);
+    if (!Number.isFinite(v) || v > 0xffffffff) return null;
+    return [(v >> 24) & 0xff, (v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
+  }
+  return null;
+}
+
+/**
+ * @param {string} host from URL.hostname (may include brackets for IPv6)
+ */
+function isBlockedIPv6Literal(host) {
+  const raw = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (raw === '::1' || raw === '0:0:0:0:0:0:0:1') return true;
+  if (raw.startsWith('fe80:')) return true;
+  if (/^f[cd][0-9a-f]{0,3}:/i.test(raw)) return true;
+  const v4m = /^::ffff:(.+)$/i.exec(raw);
+  if (v4m) {
+    const octets = ipv4MappedTailToOctets(v4m[1]);
+    if (octets) {
+      return isBlockedIPv4Octets(octets[0], octets[1]);
+    }
+  }
+  return false;
+}
+
+/**
+ * `true` if the URL may be fetched (http/https only, no creds in URL, no obvious private/local hosts).
+ * @param {string} urlStr
+ */
+export function isUrlAllowedForFetch(urlStr) {
+  let u;
+  try {
+    u = new URL(urlStr.trim());
+  } catch {
+    return false;
+  }
+  if (u.username || u.password) return false;
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+  const host = u.hostname.toLowerCase();
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) return false;
+  if (host === '::1' || isBlockedIPv6Literal(host)) return false;
+  if (isBlockedIPv4Literal(host)) return false;
+  return true;
+}
+
+/**
+ * Follow redirects manually so every hop is re-checked against {@link isUrlAllowedForFetch}.
+ * @param {string} url
+ * @param {RequestInit} [baseInit] Usually from {@link buildBotFetchRequestInit}; must use redirect 'manual' or be omitted.
+ */
+export async function botFetch(url, baseInit) {
+  const limits = getBotFetchLimits();
+  if (!isUrlAllowedForFetch(url)) {
+    throw new Error('URL is not allowed for fetch (only public http(s); blocked: localhost, private ranges, credentials in URL)');
+  }
+  const init = baseInit ? { ...baseInit, redirect: 'manual' } : buildBotFetchRequestInit();
+
+  let current = url;
+  let redirects = 0;
+
+  for (;;) {
+    const res = await fetch(current, init);
+    if (REDIRECT_STATUSES.has(res.status)) {
+      if (redirects >= limits.maxRedirects) {
+        throw new Error(`Too many redirects (limit ${limits.maxRedirects})`);
+      }
+      const loc = res.headers.get('location');
+      if (!loc || !loc.trim()) {
+        throw new Error('Redirect response missing Location header');
+      }
+      redirects += 1;
+      let next;
+      try {
+        next = new URL(loc.trim(), current).href;
+      } catch {
+        throw new Error('Invalid redirect Location URL');
+      }
+      if (!isUrlAllowedForFetch(next)) {
+        throw new Error('Redirect target is not allowed');
+      }
+      current = next;
+      continue;
+    }
+    return res;
+  }
+}
+
+/**
+ * Enforce Content-Length and post-read byte cap, then return ArrayBuffer.
+ * @param {Response} res
+ */
+export async function readResponseBodyBuffer(res, maxBytes = getBotFetchMaxResponseBytes()) {
+  const cl = res.headers.get('content-length');
+  if (cl != null && cl !== '') {
+    const n = Number(cl);
+    if (Number.isFinite(n) && n > maxBytes) {
+      throw new Error(`Response body too large (${n} bytes, limit ${maxBytes})`);
+    }
+  }
+  const buf = await res.arrayBuffer();
+  if (buf.byteLength > maxBytes) {
+    throw new Error(`Response body too large (${buf.byteLength} bytes, limit ${maxBytes})`);
+  }
+  return buf;
+}

--- a/whatsapp/utils/urlFetchSafety.js
+++ b/whatsapp/utils/urlFetchSafety.js
@@ -2,12 +2,20 @@
  * Shared guardrails for accepting user-provided URLs and fetching them in-process (SSRF reduction).
  */
 
+import net from 'node:net';
+import ipaddr from 'ipaddr.js';
+
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+const kBotFetchTimeoutMs = Symbol('botFetchTimeoutMs');
+const kBotFetchUserSignal = Symbol('botFetchUserSignal');
 
 export const DEFAULT_BOT_FETCH_TIMEOUT_MS = 45_000;
 export const DEFAULT_BOT_FETCH_MAX_REDIRECTS = 10;
 /** Hard cap on response body bytes after redirects (separate from character truncation of decoded text). */
 export const DEFAULT_BOT_FETCH_MAX_RESPONSE_BYTES = 12 * 1024 * 1024;
+/** Default cap on UTF-8 decoded characters passed to callers (e.g. Joplin note body). */
+export const DEFAULT_BOT_FETCH_MAX_HTML_CHARS = 500_000;
 
 function parsePositiveInt(value, fallback) {
   const n = parseInt(String(value), 10);
@@ -33,6 +41,20 @@ export function getBotFetchMaxResponseBytes() {
     parsePositiveInt(process.env.BOT_FETCH_MAX_RESPONSE_BYTES, DEFAULT_BOT_FETCH_MAX_RESPONSE_BYTES),
     64 * 1024 * 1024,
   );
+}
+
+/**
+ * Max characters after UTF-8 decoding for HTML/text bodies (Joplin fetch and similar).
+ * Env: `JOPLIN_FETCH_MAX_HTML_CHARS` — same variable name as historically used by the agent.
+ */
+export function getBotFetchMaxHtmlChars() {
+  const n = parseInt(
+    process.env.JOPLIN_FETCH_MAX_HTML_CHARS || String(DEFAULT_BOT_FETCH_MAX_HTML_CHARS),
+    10,
+  );
+  return Number.isFinite(n) && n > 0
+    ? Math.min(n, 2_000_000)
+    : DEFAULT_BOT_FETCH_MAX_HTML_CHARS;
 }
 
 /**
@@ -83,68 +105,49 @@ export function buildBotFetchRequestInit(opts = {}) {
     redirect: 'manual',
     signal: buildBotFetchSignal(timeoutMs, opts.signal),
     headers,
+    [kBotFetchTimeoutMs]: timeoutMs,
+    [kBotFetchUserSignal]: opts.signal,
   };
 }
 
-function isBlockedIPv4Octets(a, b) {
-  if (a === 10) return true;
-  if (a === 127 || a === 0) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  return false;
-}
-
-/** @param {string} host lowercased, dotted IPv4 or null */
-function isBlockedIPv4Literal(host) {
-  if (!host) return false;
-  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!ipv4) return false;
-  const nums = [Number(ipv4[1]), Number(ipv4[2]), Number(ipv4[3]), Number(ipv4[4])];
-  if (nums.some((n) => n > 255 || !Number.isFinite(n))) return false;
-  return isBlockedIPv4Octets(nums[0], nums[1]);
-}
-
-/** @param {string} tail IPv4-mapped tail after the `::ffff:` prefix */
-function ipv4MappedTailToOctets(tail) {
-  const t = tail.toLowerCase();
-  if (t.includes('.')) {
-    const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(t);
-    if (!m) return null;
-    const nums = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
-    return nums.every((n) => n <= 255 && Number.isFinite(n)) ? nums : null;
-  }
-  const parts = t.split(':').filter(Boolean);
-  if (parts.length === 2) {
-    const hi = parseInt(parts[0], 16);
-    const lo = parseInt(parts[1], 16);
-    if (!Number.isFinite(hi) || !Number.isFinite(lo)) return null;
-    return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff];
-  }
-  if (parts.length === 1) {
-    const v = parseInt(parts[0], 16);
-    if (!Number.isFinite(v) || v > 0xffffffff) return null;
-    return [(v >> 24) & 0xff, (v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff];
-  }
-  return null;
-}
-
 /**
- * @param {string} host from URL.hostname (may include brackets for IPv6)
+ * @param {string} host from URL.hostname (brackets already stripped by URL parser for IPv6)
  */
-function isBlockedIPv6Literal(host) {
-  const raw = host.toLowerCase().replace(/^\[|\]$/g, '');
-  if (raw === '::1' || raw === '0:0:0:0:0:0:0:1') return true;
-  if (raw.startsWith('fe80:')) return true;
-  if (/^f[cd][0-9a-f]{0,3}:/i.test(raw)) return true;
-  const v4m = /^::ffff:(.+)$/i.exec(raw);
-  if (v4m) {
-    const octets = ipv4MappedTailToOctets(v4m[1]);
-    if (octets) {
-      return isBlockedIPv4Octets(octets[0], octets[1]);
+function isBlockedIPAddressLiteral(host) {
+  const raw = (host || '').replace(/^\[|\]$/g, '');
+  if (net.isIP(raw) === 0) return false;
+  try {
+    const addr = ipaddr.parse(raw);
+    if (addr.kind() === 'ipv4') {
+      return addr.range() !== 'unicast';
     }
+    if (addr.isIPv4MappedAddress()) {
+      return isBlockedIPAddressLiteral(addr.toIPv4Address().toString());
+    }
+    return addr.range() !== 'unicast';
+  } catch {
+    return true;
   }
-  return false;
+}
+
+function cloneRequestInitForHop(baseInit) {
+  const limits = getBotFetchLimits();
+  const timeoutMs = baseInit[kBotFetchTimeoutMs] ?? limits.timeoutMs;
+  const userSignal = Object.hasOwn(baseInit, kBotFetchUserSignal)
+    ? baseInit[kBotFetchUserSignal]
+    : baseInit.signal;
+  const {
+    signal: _s,
+    redirect: _r,
+    [kBotFetchTimeoutMs]: _t,
+    [kBotFetchUserSignal]: _u,
+    ...rest
+  } = baseInit;
+  return {
+    ...rest,
+    redirect: 'manual',
+    signal: buildBotFetchSignal(timeoutMs, userSignal),
+  };
 }
 
 /**
@@ -162,8 +165,7 @@ export function isUrlAllowedForFetch(urlStr) {
   if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
   const host = u.hostname.toLowerCase();
   if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) return false;
-  if (host === '::1' || isBlockedIPv6Literal(host)) return false;
-  if (isBlockedIPv4Literal(host)) return false;
+  if (host === '::1' || isBlockedIPAddressLiteral(host)) return false;
   return true;
 }
 
@@ -177,12 +179,13 @@ export async function botFetch(url, baseInit) {
   if (!isUrlAllowedForFetch(url)) {
     throw new Error('URL is not allowed for fetch (only public http(s); blocked: localhost, private ranges, credentials in URL)');
   }
-  const init = baseInit ? { ...baseInit, redirect: 'manual' } : buildBotFetchRequestInit();
+  const template = baseInit ? { ...baseInit, redirect: 'manual' } : buildBotFetchRequestInit();
 
   let current = url;
   let redirects = 0;
 
   for (;;) {
+    const init = cloneRequestInitForHop(template);
     const res = await fetch(current, init);
     if (REDIRECT_STATUSES.has(res.status)) {
       if (redirects >= limits.maxRedirects) {
@@ -210,7 +213,7 @@ export async function botFetch(url, baseInit) {
 }
 
 /**
- * Enforce Content-Length and post-read byte cap, then return ArrayBuffer.
+ * Enforce Content-Length and streamed byte cap, then return ArrayBuffer.
  * @param {Response} res
  */
 export async function readResponseBodyBuffer(res, maxBytes = getBotFetchMaxResponseBytes()) {
@@ -221,9 +224,32 @@ export async function readResponseBodyBuffer(res, maxBytes = getBotFetchMaxRespo
       throw new Error(`Response body too large (${n} bytes, limit ${maxBytes})`);
     }
   }
-  const buf = await res.arrayBuffer();
-  if (buf.byteLength > maxBytes) {
-    throw new Error(`Response body too large (${buf.byteLength} bytes, limit ${maxBytes})`);
+  if (!res.body) {
+    return new ArrayBuffer(0);
   }
-  return buf;
+  const reader = res.body.getReader();
+  const chunks = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error(`Response body too large (${total} bytes, limit ${maxBytes})`);
+      }
+      chunks.push(value);
+    }
+  } catch (e) {
+    await reader.cancel().catch(() => {});
+    throw e;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
 }


### PR DESCRIPTION
Fixes #41

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-41-summarize-shared-url-safety-fetch-caps-module`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #41

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/41
**State:** OPEN
**Title:** Summarize: shared URL safety + fetch caps module

## Body
## Parent

#40

## What to build

Introduce a shared, reusable URL safety + fetch-limits utility that can be used by both the existing Joplin URL fetch flow and the new article summarization command.

This slice delivers a safe, bounded way to accept a user-provided URL for HTTP fetching (public http/https only) with guardrails suitable for running inside the bot process.

## Acceptance criteria

- [ ] Provide a reusable URL-allow check that blocks localhost/private network targets and credentials-in-URL
- [ ] Provide reusable fetch configuration defaults (timeouts, max bytes/chars, redirect limits) suitable for in-process usage
- [ ] Update the existing Joplin URL fetch flow to use the shared URL safety utility (no behavior regression intended)
- [ ] Add unit tests covering representative allow/deny URL cases

## Blocked by

None - can start immediately