### PR TITLE
feat: Summarize: command MVP (fetch → extract → DeepInfra) (#42)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@mozilla/readability": "^0.6.0",
         "@whiskeysockets/baileys": "^6.7.20",
         "bootstrap": "^5.3.3",
         "cors": "^2.8.5",
@@ -16,6 +17,7 @@
         "ejs": "^3.1.10",
         "express": "^4.19.2",
         "ipaddr.js": "^2.4.0",
+        "jsdom": "^29.1.1",
         "node-media-server": "^2.7.0",
         "nodemailer": "^8.0.3",
         "openai": "^4.53.2",
@@ -25,6 +27,53 @@
         "request": "^2.88.2",
         "sharp": "^0.34.5"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/runtime": {
       "version": "7.25.0",
@@ -48,6 +97,18 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@cacheable/node-cache": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@cacheable/node-cache/-/node-cache-1.6.1.tgz",
@@ -59,6 +120,140 @@
         "keyv": "^5.4.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
@@ -67,6 +262,23 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hapi/boom": {
@@ -555,6 +767,15 @@
       "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
       "license": "MIT"
     },
+    "node_modules/@mozilla/readability": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1034,6 +1255,15 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
@@ -1267,6 +1497,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1287,6 +1530,54 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/dateformat": {
@@ -1313,6 +1604,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -1444,6 +1741,18 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1927,6 +2236,18 @@
       "integrity": "sha512-dJw0492Iddsj56U1JsSTm9E/0B/29a1AuoSLRAte8vQg/kaTGF3IgjEWT8c8yG4cC10+HisE1x5QAwR0Xwc+DA==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2135,6 +2456,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -2171,6 +2498,93 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -2280,6 +2694,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2288,6 +2711,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -2558,6 +2987,18 @@
       "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -2940,6 +3381,15 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2972,6 +3422,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -3148,6 +3610,15 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -3217,6 +3688,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -3225,6 +3702,24 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -3340,6 +3835,15 @@
         "react": ">=15.0.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -3395,6 +3899,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -3407,6 +3923,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3436,6 +3961,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@mozilla/readability": "^0.6.0",
     "@whiskeysockets/baileys": "^6.7.20",
     "bootstrap": "^5.3.3",
     "cors": "^2.8.5",
@@ -7,6 +8,7 @@
     "ejs": "^3.1.10",
     "express": "^4.19.2",
     "ipaddr.js": "^2.4.0",
+    "jsdom": "^29.1.1",
     "node-media-server": "^2.7.0",
     "nodemailer": "^8.0.3",
     "openai": "^4.53.2",

--- a/test/fixtures/summarize/article.html
+++ b/test/fixtures/summarize/article.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Wildlife Weekly</title>
+  </head>
+  <body>
+    <nav><a href="/">Home</a> | <a href="/about">About</a></nav>
+    <article>
+      <h1>The secret life of pangolins</h1>
+      <p class="byline">By Example Author — 2026</p>
+      <p>
+        Pangolins are scaly mammals found in Asia and Africa. They eat ants and termites using
+        long sticky tongues. Despite international protection, they remain under heavy pressure
+        from illegal trafficking. Conservation groups track populations and run shipments
+        interdiction programs across many borders. Researchers also study their role in forest
+        soil health because their burrowing mixes organic matter into the ground. This article
+        walks through field surveys, genetic sampling, and community education efforts that
+        aim to reduce demand for scales and meat. None of this is medical advice; it is only
+        background for curious readers who want a plain-language overview before deeper reading.
+      </p>
+      <p>
+        In the second half we outline a simple mental model for why enforcement alone is not
+        enough without reducing consumer myths. Volunteers document sightings with phones and
+        shared maps, which helps biologists understand movement corridors. Meanwhile, rescue
+        centers rehabilitate injured animals when possible and release them where habitat remains.
+        The text continues with enough sentences to exceed heuristic length thresholds used by
+        extractors so automated tests have realistic material that resembles a news article body.
+      </p>
+    </article>
+    <aside>Subscribe for more stories.</aside>
+  </body>
+</html>

--- a/test/fixtures/summarize/empty-body.html
+++ b/test/fixtures/summarize/empty-body.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Minimal</title>
+  </head>
+  <body></body>
+</html>

--- a/test/summarizeCommand.test.js
+++ b/test/summarizeCommand.test.js
@@ -1,0 +1,125 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  findHttpUrlsInString,
+  normalizeUrlToken,
+  parseSummarizeMessage,
+} from '../whatsapp/utils/summarizeArgs.js';
+import { isHtmlLikeResponse } from '../whatsapp/utils/htmlResponse.js';
+import { extractArticleTextFromHtml } from '../whatsapp/utils/articleExtract.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(here, 'fixtures', 'summarize');
+
+describe('normalizeUrlToken', () => {
+  it('strips trailing punctuation from URL token', () => {
+    assert.equal(
+      normalizeUrlToken('https://example.com/path).'),
+      'https://example.com/path',
+    );
+    assert.equal(normalizeUrlToken('https://example.com/a.'), 'https://example.com/a');
+  });
+});
+
+describe('findHttpUrlsInString', () => {
+  it('finds multiple http(s) URLs', () => {
+    const s = 'see https://a.com/x and https://b.com/y';
+    assert.deepEqual(findHttpUrlsInString(s), [
+      'https://a.com/x',
+      'https://b.com/y',
+    ]);
+  });
+});
+
+describe('parseSummarizeMessage', () => {
+  it('accepts summarize spelling with one URL', () => {
+    const r = parseSummarizeMessage(
+      'summarize https://example.com/article focus on dates',
+    );
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.url, 'https://example.com/article');
+      assert.equal(r.extra, 'focus on dates');
+    }
+  });
+
+  it('accepts summarise spelling', () => {
+    const r = parseSummarizeMessage('summarise https://ex.test/');
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.url, 'https://ex.test/');
+      assert.equal(r.extra, '');
+    }
+  });
+
+  it('is case-insensitive on command word', () => {
+    const r = parseSummarizeMessage('Summarize https://ex.test/hi');
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.url, 'https://ex.test/hi');
+  });
+
+  it('fails with usage when no URL', () => {
+    const r = parseSummarizeMessage('summarize just text');
+    assert.equal(r.ok, false);
+  });
+
+  it('fails when more than one URL', () => {
+    const r = parseSummarizeMessage(
+      'summarize https://a.com/one https://b.com/two',
+    );
+    assert.equal(r.ok, false);
+  });
+
+  it('fails when extra text contains another URL', () => {
+    const r = parseSummarizeMessage(
+      'summarize https://a.com/ also see https://b.com/',
+    );
+    assert.equal(r.ok, false);
+  });
+
+  it('fails on empty payload after command', () => {
+    const r = parseSummarizeMessage('summarize');
+    assert.equal(r.ok, false);
+  });
+});
+
+describe('isHtmlLikeResponse', () => {
+  it('treats text/html as HTML', () => {
+    assert.equal(isHtmlLikeResponse('text/html', 'x'), true);
+    assert.equal(isHtmlLikeResponse('Text/HTML; charset=utf-8', ''), true);
+  });
+
+  it('rejects JSON content type', () => {
+    assert.equal(isHtmlLikeResponse('application/json', '<!DOCTYPE html><html>'), false);
+  });
+
+  it('sniffs doctype when content-type is vague', () => {
+    assert.equal(isHtmlLikeResponse('', '<!DOCTYPE html><html></html>'), true);
+  });
+});
+
+describe('extractArticleTextFromHtml (fixtures, no network)', () => {
+  it('throws when the page has no meaningful extractable text', () => {
+    const html = readFileSync(
+      path.join(fixturesDir, 'empty-body.html'),
+      'utf8',
+    );
+    assert.throws(
+      () => extractArticleTextFromHtml(html, 'https://example.com/doc'),
+      /Could not extract enough readable text/,
+    );
+  });
+
+  it('extracts long article-like HTML', () => {
+    const html = readFileSync(
+      path.join(fixturesDir, 'article.html'),
+      'utf8',
+    );
+    const text = extractArticleTextFromHtml(html, 'https://example.com/news/1');
+    assert.ok(text.length >= 80);
+    assert.match(text, /Pangolin/i);
+  });
+});

--- a/whatsapp/commands/help.js
+++ b/whatsapp/commands/help.js
@@ -6,6 +6,7 @@ export default async function helpCommand(sock, sender) {
 ━━━━━━━━━━━━━━━━━━━━━━
 • *gpt4* [prompt] — GPT-4 response
 • *deepinfra* [prompt] — DeepInfra model
+• *summarize* <https://…> [extra] — Fetch a page, extract article text, short DeepInfra summary (alias: *summarise*)
 • *wizard* [prompt] — Wizard model
 • *recipe* [prompt] — Generate a recipe
 • *image* [prompt] — Generate an image (DALL·E)

--- a/whatsapp/commands/index.js
+++ b/whatsapp/commands/index.js
@@ -7,6 +7,7 @@ import imageCommand from './image.js';
 import spriteCommand from './sprite.js';
 import danielCommand from './daniel.js';
 import cursorCommand from './cursor.js';
+import summarizeCommand from './summarize.js';
 import * as lightsCommands from './lights.js';
 
 export {
@@ -19,6 +20,8 @@ export {
     spriteCommand as sprite,
     danielCommand as daniel,
     cursorCommand as cursor,
+    summarizeCommand as summarize,
+    summarizeCommand as summarise,
 };
 
 export const hue = {

--- a/whatsapp/commands/summarize.js
+++ b/whatsapp/commands/summarize.js
@@ -1,0 +1,121 @@
+import { deepInfraAPI } from '../../models/models.js';
+import {
+  botFetch,
+  buildBotFetchRequestInit,
+  readResponseBodyBuffer,
+} from '../utils/urlFetchSafety.js';
+import { parseSummarizeMessage } from '../utils/summarizeArgs.js';
+import { extractArticleTextFromHtml } from '../utils/articleExtract.js';
+import { isHtmlLikeResponse } from '../utils/htmlResponse.js';
+
+const SUMMARIZE_USER_AGENT = 'WhatsappBot-Summarize/1.0';
+
+function maxLlmInputChars() {
+  const n = parseInt(process.env.SUMMARIZE_MAX_INPUT_CHARS || '24000', 10);
+  return Number.isFinite(n) && n > 0 ? Math.min(n, 500_000) : 24_000;
+}
+
+function buildSummaryPrompt(extractedText, extra) {
+  const instructions = extra.trim() || 'None.';
+  return [
+    'Summarize the following text extracted from a web page for a WhatsApp reader.',
+    'Be concise and accurate; do not invent facts. Use short paragraphs or bullet points.',
+    '',
+    'Optional user focus:',
+    instructions,
+    '',
+    'Extracted page text:',
+    '---',
+    extractedText,
+    '---',
+  ].join('\n');
+}
+
+/**
+ * @param {import('@whiskeysockets/baileys').WASocket} sock
+ * @param {string} sender
+ * @param {string} text full message
+ */
+export default async function summarizeCommand(sock, sender, text) {
+  const parsed = parseSummarizeMessage(text);
+  if (!parsed.ok) {
+    await sock.sendMessage(sender, { text: parsed.error });
+    return;
+  }
+
+  const { url, extra } = parsed;
+
+  let res;
+  try {
+    res = await botFetch(
+      url,
+      buildBotFetchRequestInit({ userAgent: SUMMARIZE_USER_AGENT }),
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await sock.sendMessage(sender, {
+      text: `Could not fetch URL: ${msg}`,
+    });
+    return;
+  }
+
+  if (!res.ok) {
+    await sock.sendMessage(sender, {
+      text: `Fetch failed: HTTP ${res.status} for ${url}`,
+    });
+    return;
+  }
+
+  const contentType = res.headers.get('content-type') || '';
+  let buf;
+  try {
+    buf = await readResponseBodyBuffer(res);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await sock.sendMessage(sender, {
+      text: `Could not read response body: ${msg}`,
+    });
+    return;
+  }
+
+  const html = new TextDecoder('utf-8', { fatal: false }).decode(buf);
+  if (!isHtmlLikeResponse(contentType, html)) {
+    await sock.sendMessage(sender, {
+      text:
+        'This command only supports HTML web pages. The response was not HTML (check Content-Type or body).',
+    });
+    return;
+  }
+
+  let extracted;
+  try {
+    extracted = extractArticleTextFromHtml(html, url);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await sock.sendMessage(sender, { text: msg });
+    return;
+  }
+
+  const cap = maxLlmInputChars();
+  let forModel = extracted;
+  if (forModel.length > cap) {
+    forModel = `${forModel.slice(0, cap)}\n\n[… truncated for model input length …]`;
+  }
+
+  let summary;
+  try {
+    summary = await deepInfraAPI(buildSummaryPrompt(forModel, extra));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    await sock.sendMessage(sender, {
+      text: `Summary request failed: ${msg}`,
+    });
+    return;
+  }
+
+  const out =
+    typeof summary === 'string' && summary.trim()
+      ? summary.trim()
+      : 'The model returned an empty summary.';
+  await sock.sendMessage(sender, { text: out });
+}

--- a/whatsapp/utils/articleExtract.js
+++ b/whatsapp/utils/articleExtract.js
@@ -1,0 +1,55 @@
+import { Readability } from '@mozilla/readability';
+import { JSDOM } from 'jsdom';
+
+/** Enough characters for Readability output to count as usable article text. */
+const MIN_READABILITY_CHARS = 120;
+/** Lower bar for tag-stripped body text fallback. */
+const MIN_FALLBACK_CHARS = 80;
+
+function normalizeWhitespace(text) {
+  return String(text || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * @param {import('jsdom').DOMWindow['document']} document
+ */
+function fallbackPlainText(document) {
+  const body = document.body;
+  if (!body) return '';
+  const clone = /** @type {HTMLElement} */ (body.cloneNode(true));
+  for (const sel of ['script', 'style', 'noscript', 'template', 'iframe']) {
+    clone.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return clone.textContent || '';
+}
+
+/**
+ * Extract main article text using Readability, then a simple DOM fallback.
+ * @param {string} html
+ * @param {string} documentUrl resolved URL for relative links (Readability)
+ */
+export function extractArticleTextFromHtml(html, documentUrl) {
+  const dom = new JSDOM(html, { url: documentUrl });
+  const doc = dom.window.document;
+  const reader = new Readability(doc);
+  const article = reader.parse();
+  let fromReader = '';
+  if (article?.textContent) {
+    fromReader = normalizeWhitespace(article.textContent);
+  }
+  if (fromReader.length >= MIN_READABILITY_CHARS) {
+    return fromReader;
+  }
+
+  const dom2 = new JSDOM(html, { url: documentUrl });
+  const fallback = normalizeWhitespace(fallbackPlainText(dom2.window.document));
+  if (fallback.length >= MIN_FALLBACK_CHARS) {
+    return fallback;
+  }
+
+  throw new Error(
+    'Could not extract enough readable text from this page (empty or navigation-only HTML).',
+  );
+}

--- a/whatsapp/utils/htmlResponse.js
+++ b/whatsapp/utils/htmlResponse.js
@@ -1,0 +1,29 @@
+/**
+ * @param {string} contentType value of Content-Type without parameters normalization optional
+ * @param {string} bodyText decoded response body
+ */
+export function isHtmlLikeResponse(contentType, bodyText) {
+  const ct = String(contentType || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+  if (ct.includes('text/html') || ct.includes('application/xhtml+xml')) {
+    return true;
+  }
+  if (
+    ct.startsWith('application/json') ||
+    ct.startsWith('image/') ||
+    ct.startsWith('video/') ||
+    ct.startsWith('audio/') ||
+    ct === 'application/pdf' ||
+    ct.endsWith('+json')
+  ) {
+    return false;
+  }
+
+  const head = String(bodyText || '').trimStart().slice(0, 8000);
+  if (/^<!DOCTYPE\s+html/i.test(head)) return true;
+  if (/^<html[\s>]/i.test(head)) return true;
+  if (/^<\?xml/i.test(head) && /<html[\s>]/i.test(head)) return true;
+  return false;
+}

--- a/whatsapp/utils/summarizeArgs.js
+++ b/whatsapp/utils/summarizeArgs.js
@@ -1,0 +1,68 @@
+/** Usage line sent when parsing fails (0 or multiple URLs, missing args). */
+export const SUMMARIZE_USAGE =
+  'Usage: *summarize* <https://…> [optional extra instructions]\n(Same with *summarise*.)';
+
+const CMD_RE = /^summari(ze|se)\b\s*(.*)$/is;
+
+/**
+ * Strip common trailing punctuation from a URL token matched inside user text.
+ * @param {string} raw
+ */
+export function normalizeUrlToken(raw) {
+  return raw.replace(/[.,;:!?)\]]+$/u, '');
+}
+
+const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"']+/gi;
+
+/**
+ * @param {string} s
+ * @returns {string[]}
+ */
+export function findHttpUrlsInString(s) {
+  const matches = s.match(URL_IN_TEXT_RE);
+  if (!matches) return [];
+  return matches.map(normalizeUrlToken);
+}
+
+/**
+ * @param {string} fullText full WhatsApp message (starts with summarize / summarise)
+ * @returns {{ ok: true, url: string, extra: string } | { ok: false, error: string }}
+ */
+export function parseSummarizeMessage(fullText) {
+  const m = String(fullText || '').match(CMD_RE);
+  if (!m) {
+    return { ok: false, error: SUMMARIZE_USAGE };
+  }
+  const remainder = (m[2] || '').trim();
+  if (!remainder) {
+    return { ok: false, error: SUMMARIZE_USAGE };
+  }
+  const urlMatches = [...remainder.matchAll(URL_IN_TEXT_RE)];
+  if (urlMatches.length === 0) {
+    return {
+      ok: false,
+      error: `${SUMMARIZE_USAGE}\n\nNo URL found. Include one https://… or http://… link.`,
+    };
+  }
+  if (urlMatches.length > 1) {
+    return {
+      ok: false,
+      error: `${SUMMARIZE_USAGE}\n\nOnly one URL is allowed per request.`,
+    };
+  }
+  const rawToken = urlMatches[0][0];
+  const idx = urlMatches[0].index ?? 0;
+  const url = normalizeUrlToken(rawToken);
+  const extra = (remainder.slice(0, idx) + remainder.slice(idx + rawToken.length))
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—\-–:]\s*/, '')
+    .trim();
+  if (findHttpUrlsInString(extra).length > 0) {
+    return {
+      ok: false,
+      error: `${SUMMARIZE_USAGE}\n\nOnly one URL is allowed per request.`,
+    };
+  }
+  return { ok: true, url, extra };
+}


### PR DESCRIPTION
Fixes #42

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-42-summarize-command-mvp-fetch-extract-deepinfra`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #42

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/42
**State:** OPEN
**Title:** Summarize: command MVP (fetch → extract → DeepInfra)

## Body
## Parent

#40

## What to build

Add a new WhatsApp command `summarize <url> [extra instructions]` and `summarise <url> [extra instructions]` that fetches the URL, extracts main readable HTML article text using open-source tooling (Readability + DOM parsing), then generates a concise summary via the existing DeepInfra LLM client.

This slice must be deterministic in routing (command-based), stateless (no chat memory pollution), and fail-fast on fetch/extraction problems.

## Acceptance criteria

- [ ] Command routing works for both spellings and runs before the smart-agent chain
- [ ] Input parsing enforces exactly one URL; optional trailing instructions are accepted; 0 or >1 URLs fail with a usage hint
- [ ] Fetch uses the shared URL safety + guardrails module and fails fast on non-OK HTTP status
- [ ] Only HTML-like responses are supported; non-HTML fails fast with a clear message
- [ ] Extraction uses Readability first and a simple fallback extractor if Readability is insufficient; fails fast if still insufficient
- [ ] Summary is generated via DeepInfra (default model) using truncated extracted text to keep cost bounded
- [ ] Add tests for URL parsing and extraction-failure behavior using fixtures (no network in tests)

## Blocked by

- Blocked by #41