### PR TITLE
feat: Summarize: help entry + structured logging (#44)

### DIFF
--- a/models/models.js
+++ b/models/models.js
@@ -61,9 +61,12 @@ export const deepInfra = new OpenAI({
   apiKey: process.env.DEEPINFRA_API_KEY,
 });
 
+/** Default chat model for `deepInfraAPI` when `model` is omitted. */
+export const DEEPINFRA_DEFAULT_CHAT_MODEL = 'deepseek-ai/DeepSeek-V3';
+
 export async function deepInfraAPI(
   content,
-  model = 'deepseek-ai/DeepSeek-V3',
+  model = DEEPINFRA_DEFAULT_CHAT_MODEL,
   options = {},
 ) {
   const { signal } = options;

--- a/test/helpCommand.test.js
+++ b/test/helpCommand.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import helpCommand from '../whatsapp/commands/help.js';
+import { SUMMARIZE_USAGE } from '../whatsapp/utils/summarizeArgs.js';
+
+describe('help command text', () => {
+  it('includes the summarize usage aligned with SUMMARIZE_USAGE ([extra])', async () => {
+    /** @type {string[]} */
+    const texts = [];
+    const sock = {
+      sendMessage: async (/** @type {string} */ _jid, /** @type {{ text?: string }} */ content) => {
+        texts.push(String(content?.text ?? ''));
+      },
+    };
+
+    await helpCommand(sock, '15551234567@s.whatsapp.net');
+
+    assert.equal(texts.length, 1);
+    const helpText = texts[0];
+    assert.match(
+      helpText,
+      /\*summarize\*\|\*summarise\* <url> \[extra\]/,
+      'help bullet should use [extra] like parse errors',
+    );
+    assert.match(
+      helpText,
+      /Optional focus text after the URL/,
+      'help should explain what [extra] means',
+    );
+    assert.equal(
+      SUMMARIZE_USAGE,
+      'Usage: *summarize*|*summarise* <url> [extra]',
+    );
+  });
+});

--- a/test/summarizeCommand.test.js
+++ b/test/summarizeCommand.test.js
@@ -4,12 +4,15 @@ import {
   findHttpUrlsInString,
   normalizeUrlToken,
   parseSummarizeMessage,
+  SUMMARIZE_USAGE,
 } from '../whatsapp/utils/summarizeArgs.js';
 import { isHtmlLikeResponse } from '../whatsapp/utils/htmlResponse.js';
 import { extractArticleTextFromHtml } from '../whatsapp/utils/articleExtract.js';
+import { DEEPINFRA_DEFAULT_CHAT_MODEL } from '../models/models.js';
 import summarizeCommand, {
   SUMMARIZE_ACK,
   SUMMARIZE_BUSY,
+  summarizeInjectedDeps,
 } from '../whatsapp/commands/summarize.js';
 import {
   resetSummarizeLockState,
@@ -73,6 +76,9 @@ describe('parseSummarizeMessage', () => {
   it('fails with usage when no URL', () => {
     const r = parseSummarizeMessage('summarize just text');
     assert.equal(r.ok, false);
+    if (!r.ok) {
+      assert.ok(r.error.includes(SUMMARIZE_USAGE));
+    }
   });
 
   it('fails when more than one URL', () => {
@@ -134,6 +140,24 @@ describe('extractArticleTextFromHtml (fixtures, no network)', () => {
 });
 
 const SENDER = '15551234567@s.whatsapp.net';
+
+const HTML_ONLY_MSG =
+  'This command only supports HTML web pages. The response was not HTML (check Content-Type or body).';
+
+/** @param {unknown} line */
+function assertSummarizeLogHasNoPageTextLeak(line) {
+  const json = JSON.stringify(line);
+  assert.match(
+    json,
+    /"event":"summarize_run"/,
+    'expected single structured summarize_run payload',
+  );
+  assert.ok(
+    !json.includes('Pangolin'),
+    'log must not include extracted page text',
+  );
+  assert.ok(json.length < 900, 'log payload should stay small (no bodies or prompts)');
+}
 
 describe('summarize command (WhatsApp lock UX)', () => {
   beforeEach(() => {
@@ -199,11 +223,16 @@ describe('summarize command (WhatsApp lock UX)', () => {
       },
     };
 
-    await summarizeCommand(sock, SENDER, 'summarize https://example.com/news/1 brief', {
-      botFetch: fakeBotFetch,
-      deepInfraAPI: fakeDeepInfra,
-      logger,
-    });
+    await summarizeCommand(
+      sock,
+      SENDER,
+      'summarize https://example.com/news/1 brief',
+      summarizeInjectedDeps({
+        botFetch: fakeBotFetch,
+        deepInfraAPI: fakeDeepInfra,
+        logger,
+      }),
+    );
 
     assert.deepEqual(
       sent.map((m) => m.text),
@@ -218,10 +247,11 @@ describe('summarize command (WhatsApp lock UX)', () => {
     assert.equal(typeof line.extractedLength, 'number');
     assert.ok((/** @type {number} */ (line.extractedLength)) >= 80);
     assert.equal(line.outcome, 'success');
-    assert.equal(line.model, 'deepseek-ai/DeepSeek-V3');
+    assert.equal(line.model, DEEPINFRA_DEFAULT_CHAT_MODEL);
     assert.equal(line.provider, 'deepinfra');
     assert.equal(typeof line.durationMs, 'number');
     assert.ok((/** @type {number} */ (line.durationMs)) >= 0);
+    assertSummarizeLogHasNoPageTextLeak(line);
   });
 
   it('emits summarize_run with http_error when the fetch returns non-OK', async () => {
@@ -247,10 +277,15 @@ describe('summarize command (WhatsApp lock UX)', () => {
       },
     };
 
-    await summarizeCommand(sock, SENDER, 'summarize https://example.com/missing', {
-      botFetch: fakeBotFetch404,
-      logger,
-    });
+    await summarizeCommand(
+      sock,
+      SENDER,
+      'summarize https://example.com/missing',
+      summarizeInjectedDeps({
+        botFetch: fakeBotFetch404,
+        logger,
+      }),
+    );
 
     assert.ok(sent.length >= 2);
     assert.equal(sent[0].text, SUMMARIZE_ACK);
@@ -263,6 +298,143 @@ describe('summarize command (WhatsApp lock UX)', () => {
     assert.equal(line.httpStatus, 404);
     assert.equal(line.extractedLength, null);
     assert.equal(line.outcome, 'http_error');
-    assert.ok(!/article\.html|Pangolin/i.test(JSON.stringify(line)));
+    assertSummarizeLogHasNoPageTextLeak(line);
+  });
+
+  it('emits summarize_run with fetch_error and null http status when fetch throws', async () => {
+    async function fakeBotFetchThrows() {
+      throw new Error('network down');
+    }
+
+    /** @type {unknown[]} */
+    const logPayloads = [];
+    const logger = {
+      info(/** @type {Record<string, unknown>} */ o) {
+        logPayloads.push(o);
+      },
+    };
+
+    const sent = [];
+    const sock = {
+      sendMessage: async (jid, content) => {
+        sent.push({ jid, text: String(content?.text ?? '') });
+      },
+    };
+
+    await summarizeCommand(
+      sock,
+      SENDER,
+      'summarize https://example.com/news/1',
+      summarizeInjectedDeps({ botFetch: fakeBotFetchThrows, logger }),
+    );
+
+    assert.match(sent[sent.length - 1].text, /Could not fetch URL/);
+
+    assert.equal(logPayloads.length, 1);
+    const line = /** @type {Record<string, unknown>} */ (logPayloads[0]);
+    assert.equal(line.event, 'summarize_run');
+    assert.equal(line.host, 'example.com');
+    assert.equal(line.httpStatus, null);
+    assert.equal(line.extractedLength, null);
+    assert.equal(line.outcome, 'fetch_error');
+    assert.equal(line.model, DEEPINFRA_DEFAULT_CHAT_MODEL);
+    assertSummarizeLogHasNoPageTextLeak(line);
+  });
+
+  it('emits summarize_run with not_html when the body is not HTML', async () => {
+    async function fakeBotFetchJson() {
+      return new Response('{"x":1}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    /** @type {unknown[]} */
+    const logPayloads = [];
+    const logger = {
+      info(/** @type {Record<string, unknown>} */ o) {
+        logPayloads.push(o);
+      },
+    };
+
+    const sent = [];
+    const sock = {
+      sendMessage: async (jid, content) => {
+        sent.push({ jid, text: String(content?.text ?? '') });
+      },
+    };
+
+    await summarizeCommand(
+      sock,
+      SENDER,
+      'summarize https://example.com/data.json',
+      summarizeInjectedDeps({ botFetch: fakeBotFetchJson, logger }),
+    );
+
+    assert.equal(sent[sent.length - 1].text, HTML_ONLY_MSG);
+
+    assert.equal(logPayloads.length, 1);
+    const line = /** @type {Record<string, unknown>} */ (logPayloads[0]);
+    assert.equal(line.event, 'summarize_run');
+    assert.equal(line.host, 'example.com');
+    assert.equal(line.httpStatus, 200);
+    assert.equal(line.extractedLength, null);
+    assert.equal(line.outcome, 'not_html');
+    assert.equal(line.model, DEEPINFRA_DEFAULT_CHAT_MODEL);
+    assertSummarizeLogHasNoPageTextLeak(line);
+  });
+
+  it('emits summarize_run with llm_error when the model call throws', async () => {
+    const articleHtml = readFileSync(path.join(fixturesDir, 'article.html'), 'utf8');
+
+    async function fakeBotFetch() {
+      return new Response(articleHtml, {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    async function fakeDeepInfraThrows() {
+      throw new Error('DeepInfra refused');
+    }
+
+    /** @type {unknown[]} */
+    const logPayloads = [];
+    const logger = {
+      info(/** @type {Record<string, unknown>} */ o) {
+        logPayloads.push(o);
+      },
+    };
+
+    const sent = [];
+    const sock = {
+      sendMessage: async (jid, content) => {
+        sent.push({ jid, text: String(content?.text ?? '') });
+      },
+    };
+
+    await summarizeCommand(
+      sock,
+      SENDER,
+      'summarize https://example.com/news/1',
+      summarizeInjectedDeps({
+        botFetch: fakeBotFetch,
+        deepInfraAPI: fakeDeepInfraThrows,
+        logger,
+      }),
+    );
+
+    assert.match(sent[sent.length - 1].text, /Summary request failed/);
+
+    assert.equal(logPayloads.length, 1);
+    const line = /** @type {Record<string, unknown>} */ (logPayloads[0]);
+    assert.equal(line.event, 'summarize_run');
+    assert.equal(line.host, 'example.com');
+    assert.equal(line.httpStatus, 200);
+    assert.equal(typeof line.extractedLength, 'number');
+    assert.ok((/** @type {number} */ (line.extractedLength)) >= 80);
+    assert.equal(line.outcome, 'llm_error');
+    assert.equal(line.model, DEEPINFRA_DEFAULT_CHAT_MODEL);
+    assertSummarizeLogHasNoPageTextLeak(line);
   });
 });

--- a/test/summarizeCommand.test.js
+++ b/test/summarizeCommand.test.js
@@ -184,6 +184,14 @@ describe('summarize command (WhatsApp lock UX)', () => {
       return 'Mocked summary bullets.';
     }
 
+    /** @type {unknown[]} */
+    const logPayloads = [];
+    const logger = {
+      info(/** @type {Record<string, unknown>} */ o) {
+        logPayloads.push(o);
+      },
+    };
+
     const sent = [];
     const sock = {
       sendMessage: async (jid, content) => {
@@ -194,11 +202,67 @@ describe('summarize command (WhatsApp lock UX)', () => {
     await summarizeCommand(sock, SENDER, 'summarize https://example.com/news/1 brief', {
       botFetch: fakeBotFetch,
       deepInfraAPI: fakeDeepInfra,
+      logger,
     });
 
     assert.deepEqual(
       sent.map((m) => m.text),
       [SUMMARIZE_ACK, 'Mocked summary bullets.'],
     );
+
+    assert.equal(logPayloads.length, 1);
+    const line = /** @type {Record<string, unknown>} */ (logPayloads[0]);
+    assert.equal(line.event, 'summarize_run');
+    assert.equal(line.host, 'example.com');
+    assert.equal(line.httpStatus, 200);
+    assert.equal(typeof line.extractedLength, 'number');
+    assert.ok((/** @type {number} */ (line.extractedLength)) >= 80);
+    assert.equal(line.outcome, 'success');
+    assert.equal(line.model, 'deepseek-ai/DeepSeek-V3');
+    assert.equal(line.provider, 'deepinfra');
+    assert.equal(typeof line.durationMs, 'number');
+    assert.ok((/** @type {number} */ (line.durationMs)) >= 0);
+  });
+
+  it('emits summarize_run with http_error when the fetch returns non-OK', async () => {
+    async function fakeBotFetch404() {
+      return new Response('', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    /** @type {unknown[]} */
+    const logPayloads = [];
+    const logger = {
+      info(/** @type {Record<string, unknown>} */ o) {
+        logPayloads.push(o);
+      },
+    };
+
+    const sent = [];
+    const sock = {
+      sendMessage: async (jid, content) => {
+        sent.push({ jid, text: String(content?.text ?? '') });
+      },
+    };
+
+    await summarizeCommand(sock, SENDER, 'summarize https://example.com/missing', {
+      botFetch: fakeBotFetch404,
+      logger,
+    });
+
+    assert.ok(sent.length >= 2);
+    assert.equal(sent[0].text, SUMMARIZE_ACK);
+    assert.match(sent[sent.length - 1].text, /HTTP 404/);
+
+    assert.equal(logPayloads.length, 1);
+    const line = /** @type {Record<string, unknown>} */ (logPayloads[0]);
+    assert.equal(line.event, 'summarize_run');
+    assert.equal(line.host, 'example.com');
+    assert.equal(line.httpStatus, 404);
+    assert.equal(line.extractedLength, null);
+    assert.equal(line.outcome, 'http_error');
+    assert.ok(!/article\.html|Pangolin/i.test(JSON.stringify(line)));
   });
 });

--- a/whatsapp/commands/help.js
+++ b/whatsapp/commands/help.js
@@ -6,7 +6,7 @@ export default async function helpCommand(sock, sender) {
 ━━━━━━━━━━━━━━━━━━━━━━
 • *gpt4* [prompt] — GPT-4 response
 • *deepinfra* [prompt] — DeepInfra model
-• *summarize*|*summarise* <url> [extra] — Fetch a page, extract article text, short DeepInfra summary
+• *summarize*|*summarise* <url> [extra] — Optional focus text after the URL. Fetch page, extract article text, short DeepInfra summary
 • *wizard* [prompt] — Wizard model
 • *recipe* [prompt] — Generate a recipe
 • *image* [prompt] — Generate an image (DALL·E)

--- a/whatsapp/commands/help.js
+++ b/whatsapp/commands/help.js
@@ -6,7 +6,7 @@ export default async function helpCommand(sock, sender) {
 ━━━━━━━━━━━━━━━━━━━━━━
 • *gpt4* [prompt] — GPT-4 response
 • *deepinfra* [prompt] — DeepInfra model
-• *summarize* <https://…> [extra] — Fetch a page, extract article text, short DeepInfra summary (alias: *summarise*)
+• *summarize*|*summarise* <url> [extra] — Fetch a page, extract article text, short DeepInfra summary
 • *wizard* [prompt] — Wizard model
 • *recipe* [prompt] — Generate a recipe
 • *image* [prompt] — Generate an image (DALL·E)

--- a/whatsapp/commands/summarize.js
+++ b/whatsapp/commands/summarize.js
@@ -1,5 +1,5 @@
 import pino from 'pino';
-import { deepInfraAPI } from '../../models/models.js';
+import { deepInfraAPI, DEEPINFRA_DEFAULT_CHAT_MODEL } from '../../models/models.js';
 import {
   botFetch,
   buildBotFetchRequestInit,
@@ -13,28 +13,65 @@ import {
   tryAcquireSummarizeLock,
 } from '../utils/summarizeLock.js';
 
-/** Matches `deepInfraAPI` default model in `models/models.js`. */
-const SUMMARIZE_DEFAULT_MODEL = 'deepseek-ai/DeepSeek-V3';
+/** Test-only: marks injected `{ botFetch?, deepInfraAPI?, logger? }` so raw WhatsApp messages are never mistaken for deps. */
+const summarizeInjectedDepsBrand = Symbol.for('WhatsappBot.summarize.injectedDeps');
+
+/**
+ * Wrap test-only `{ botFetch?, deepInfraAPI?, logger? }`. Production passes the raw Baileys
+ * message as the 4th argument; it must not be mistaken for injected deps.
+ * @param {{ botFetch?: typeof botFetch; deepInfraAPI?: typeof deepInfraAPI; logger?: { info: Function } }} partial
+ */
+export function summarizeInjectedDeps(partial) {
+  return { [summarizeInjectedDepsBrand]: true, ...partial };
+}
 
 const summarizeRunLogger = pino({ level: process.env.LOG_LEVEL || 'info' });
 
 /**
- * Production invokes commands as `(sock, chatId, text, raw)`; tests inject `{ botFetch, deepInfraAPI, logger }`.
- * @param {unknown} rawOrDeps
+ * @param {unknown} fourthArg raw Baileys message in production, or {@link summarizeInjectedDeps} in tests
  */
-function resolveSummarizeDeps(rawOrDeps) {
+function resolveSummarizeDeps(fourthArg) {
   if (
-    rawOrDeps != null &&
-    typeof rawOrDeps === 'object' &&
-    ('botFetch' in rawOrDeps ||
-      'deepInfraAPI' in rawOrDeps ||
-      'logger' in rawOrDeps)
+    fourthArg != null &&
+    typeof fourthArg === 'object' &&
+    /** @type {Record<symbol, unknown>} */ (fourthArg)[summarizeInjectedDepsBrand] === true
   ) {
+    const { [summarizeInjectedDepsBrand]: _b, ...rest } = /** @type {Record<symbol | string, unknown>} */ (
+      fourthArg
+    );
     return /** @type {{ botFetch?: typeof botFetch; deepInfraAPI?: typeof deepInfraAPI; logger?: { info: Function } }} */ (
-      rawOrDeps
+      rest
     );
   }
   return {};
+}
+
+/**
+ * One JSON log object per summarize run (no page body or prompts).
+ * Every key is always present: use null when a value does not apply (see outcome).
+ *
+ * @param {{ info: (o: object) => void }} log
+ * @param {{
+ *   host: string;
+ *   httpStatus: number | null;
+ *   extractedLength: number | null;
+ *   startedAt: number;
+ *   model: string;
+ *   outcome: string;
+ * }} fields
+ */
+function logSummarizeRun(log, { host, httpStatus, extractedLength, startedAt, model, outcome }) {
+  log.info({
+    event: 'summarize_run',
+    host: host || '',
+    httpStatus: httpStatus === null || httpStatus === undefined ? null : httpStatus,
+    extractedLength:
+      extractedLength === null || extractedLength === undefined ? null : extractedLength,
+    durationMs: Date.now() - startedAt,
+    model,
+    provider: 'deepinfra',
+    outcome,
+  });
 }
 
 export const SUMMARIZE_ACK =
@@ -69,10 +106,10 @@ function buildSummaryPrompt(extractedText, extra) {
  * @param {import('@whiskeysockets/baileys').WASocket} sock
  * @param {string} sender
  * @param {string} text full message
- * @param {unknown} [rawOrDeps] raw Baileys message in production, or test deps `{ botFetch?, deepInfraAPI?, logger? }`
+ * @param {unknown} [fourthArg] raw Baileys message in production, or {@link summarizeInjectedDeps} in tests
  */
-export default async function summarizeCommand(sock, sender, text, rawOrDeps = {}) {
-  const deps = resolveSummarizeDeps(rawOrDeps);
+export default async function summarizeCommand(sock, sender, text, fourthArg) {
+  const deps = resolveSummarizeDeps(fourthArg);
   const fetchPage = deps.botFetch ?? botFetch;
   const runLlm = deps.deepInfraAPI ?? deepInfraAPI;
   const log = deps.logger ?? summarizeRunLogger;
@@ -91,8 +128,11 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
   const { leaseId: summarizeLeaseId, signal: summarizeSignal } = summarizeLease;
 
   const startedAt = Date.now();
+  /** Hostname from URL, or '' if parsing failed. */
   let host = '';
+  /** Set only after a Response exists; null on fetch/network errors before that. */
   let httpStatus = /** @type {number | null} */ (null);
+  /** Character length of extracted article text; null until extraction succeeds. */
   let extractedLength = /** @type {number | null} */ (null);
   let outcome = 'unknown';
 
@@ -118,6 +158,8 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
       );
     } catch (e) {
       outcome = 'fetch_error';
+      httpStatus = null;
+      extractedLength = null;
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, {
         text: `Could not fetch URL: ${msg}`,
@@ -128,6 +170,7 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
     httpStatus = res.status;
     if (!res.ok) {
       outcome = 'http_error';
+      extractedLength = null;
       await sock.sendMessage(sender, {
         text: `Fetch failed: HTTP ${res.status} for ${url}`,
       });
@@ -140,6 +183,7 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
       buf = await readResponseBodyBuffer(res);
     } catch (e) {
       outcome = 'read_body_error';
+      extractedLength = null;
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, {
         text: `Could not read response body: ${msg}`,
@@ -150,6 +194,7 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
     const html = new TextDecoder('utf-8', { fatal: false }).decode(buf);
     if (!isHtmlLikeResponse(contentType, html)) {
       outcome = 'not_html';
+      extractedLength = null;
       await sock.sendMessage(sender, {
         text:
           'This command only supports HTML web pages. The response was not HTML (check Content-Type or body).',
@@ -162,6 +207,7 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
       extracted = extractArticleTextFromHtml(html, url);
     } catch (e) {
       outcome = 'extract_error';
+      extractedLength = null;
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, { text: msg });
       return;
@@ -177,7 +223,7 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
 
     let summary;
     try {
-      summary = await runLlm(buildSummaryPrompt(forModel, extra), undefined, {
+      summary = await runLlm(buildSummaryPrompt(forModel, extra), DEEPINFRA_DEFAULT_CHAT_MODEL, {
         signal: summarizeSignal,
       });
     } catch (e) {
@@ -196,14 +242,12 @@ export default async function summarizeCommand(sock, sender, text, rawOrDeps = {
         : 'The model returned an empty summary.';
     await sock.sendMessage(sender, { text: out });
   } finally {
-    log.info({
-      event: 'summarize_run',
+    logSummarizeRun(log, {
       host,
       httpStatus,
       extractedLength,
-      durationMs: Date.now() - startedAt,
-      model: SUMMARIZE_DEFAULT_MODEL,
-      provider: 'deepinfra',
+      startedAt,
+      model: DEEPINFRA_DEFAULT_CHAT_MODEL,
       outcome,
     });
     releaseSummarizeLock(summarizeLeaseId);

--- a/whatsapp/commands/summarize.js
+++ b/whatsapp/commands/summarize.js
@@ -1,3 +1,4 @@
+import pino from 'pino';
 import { deepInfraAPI } from '../../models/models.js';
 import {
   botFetch,
@@ -11,6 +12,30 @@ import {
   releaseSummarizeLock,
   tryAcquireSummarizeLock,
 } from '../utils/summarizeLock.js';
+
+/** Matches `deepInfraAPI` default model in `models/models.js`. */
+const SUMMARIZE_DEFAULT_MODEL = 'deepseek-ai/DeepSeek-V3';
+
+const summarizeRunLogger = pino({ level: process.env.LOG_LEVEL || 'info' });
+
+/**
+ * Production invokes commands as `(sock, chatId, text, raw)`; tests inject `{ botFetch, deepInfraAPI, logger }`.
+ * @param {unknown} rawOrDeps
+ */
+function resolveSummarizeDeps(rawOrDeps) {
+  if (
+    rawOrDeps != null &&
+    typeof rawOrDeps === 'object' &&
+    ('botFetch' in rawOrDeps ||
+      'deepInfraAPI' in rawOrDeps ||
+      'logger' in rawOrDeps)
+  ) {
+    return /** @type {{ botFetch?: typeof botFetch; deepInfraAPI?: typeof deepInfraAPI; logger?: { info: Function } }} */ (
+      rawOrDeps
+    );
+  }
+  return {};
+}
 
 export const SUMMARIZE_ACK =
   'On it — fetching the page and drafting your summary.';
@@ -44,11 +69,13 @@ function buildSummaryPrompt(extractedText, extra) {
  * @param {import('@whiskeysockets/baileys').WASocket} sock
  * @param {string} sender
  * @param {string} text full message
- * @param {{ botFetch?: typeof botFetch, deepInfraAPI?: typeof deepInfraAPI }} [deps] tests may inject fetch/LLM stubs
+ * @param {unknown} [rawOrDeps] raw Baileys message in production, or test deps `{ botFetch?, deepInfraAPI?, logger? }`
  */
-export default async function summarizeCommand(sock, sender, text, deps = {}) {
+export default async function summarizeCommand(sock, sender, text, rawOrDeps = {}) {
+  const deps = resolveSummarizeDeps(rawOrDeps);
   const fetchPage = deps.botFetch ?? botFetch;
   const runLlm = deps.deepInfraAPI ?? deepInfraAPI;
+  const log = deps.logger ?? summarizeRunLogger;
 
   const parsed = parseSummarizeMessage(text);
   if (!parsed.ok) {
@@ -63,10 +90,22 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
   }
   const { leaseId: summarizeLeaseId, signal: summarizeSignal } = summarizeLease;
 
+  const startedAt = Date.now();
+  let host = '';
+  let httpStatus = /** @type {number | null} */ (null);
+  let extractedLength = /** @type {number | null} */ (null);
+  let outcome = 'unknown';
+
   try {
     await sock.sendMessage(sender, { text: SUMMARIZE_ACK });
 
     const { url, extra } = parsed;
+
+    try {
+      host = new URL(url).hostname;
+    } catch {
+      host = '';
+    }
 
     let res;
     try {
@@ -78,6 +117,7 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
         }),
       );
     } catch (e) {
+      outcome = 'fetch_error';
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, {
         text: `Could not fetch URL: ${msg}`,
@@ -85,7 +125,9 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
       return;
     }
 
+    httpStatus = res.status;
     if (!res.ok) {
+      outcome = 'http_error';
       await sock.sendMessage(sender, {
         text: `Fetch failed: HTTP ${res.status} for ${url}`,
       });
@@ -97,6 +139,7 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
     try {
       buf = await readResponseBodyBuffer(res);
     } catch (e) {
+      outcome = 'read_body_error';
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, {
         text: `Could not read response body: ${msg}`,
@@ -106,6 +149,7 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
 
     const html = new TextDecoder('utf-8', { fatal: false }).decode(buf);
     if (!isHtmlLikeResponse(contentType, html)) {
+      outcome = 'not_html';
       await sock.sendMessage(sender, {
         text:
           'This command only supports HTML web pages. The response was not HTML (check Content-Type or body).',
@@ -117,10 +161,13 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
     try {
       extracted = extractArticleTextFromHtml(html, url);
     } catch (e) {
+      outcome = 'extract_error';
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, { text: msg });
       return;
     }
+
+    extractedLength = extracted.length;
 
     const cap = maxLlmInputChars();
     let forModel = extracted;
@@ -134,6 +181,7 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
         signal: summarizeSignal,
       });
     } catch (e) {
+      outcome = 'llm_error';
       const msg = e instanceof Error ? e.message : String(e);
       await sock.sendMessage(sender, {
         text: `Summary request failed: ${msg}`,
@@ -141,12 +189,23 @@ export default async function summarizeCommand(sock, sender, text, deps = {}) {
       return;
     }
 
+    outcome = 'success';
     const out =
       typeof summary === 'string' && summary.trim()
         ? summary.trim()
         : 'The model returned an empty summary.';
     await sock.sendMessage(sender, { text: out });
   } finally {
+    log.info({
+      event: 'summarize_run',
+      host,
+      httpStatus,
+      extractedLength,
+      durationMs: Date.now() - startedAt,
+      model: SUMMARIZE_DEFAULT_MODEL,
+      provider: 'deepinfra',
+      outcome,
+    });
     releaseSummarizeLock(summarizeLeaseId);
   }
 }

--- a/whatsapp/utils/summarizeArgs.js
+++ b/whatsapp/utils/summarizeArgs.js
@@ -1,6 +1,6 @@
 /** Usage line sent when parsing fails (0 or multiple URLs, missing args). */
 export const SUMMARIZE_USAGE =
-  'Usage: *summarize* <https://…> [optional extra instructions]\n(Same with *summarise*.)';
+  'Usage: *summarize*|*summarise* <url> [optional extra instructions]';
 
 const CMD_RE = /^summari(ze|se)\b\s*(.*)$/is;
 

--- a/whatsapp/utils/summarizeArgs.js
+++ b/whatsapp/utils/summarizeArgs.js
@@ -1,6 +1,6 @@
-/** Usage line sent when parsing fails (0 or multiple URLs, missing args). */
+/** Usage line sent when parsing fails (0 or multiple URLs, missing args). Align with `help.js` bullet. */
 export const SUMMARIZE_USAGE =
-  'Usage: *summarize*|*summarise* <url> [optional extra instructions]';
+  'Usage: *summarize*|*summarise* <url> [extra]';
 
 const CMD_RE = /^summari(ze|se)\b\s*(.*)$/is;
 


### PR DESCRIPTION
Fixes #44

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-44-summarize-help-entry-structured-logging`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #44

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/44
**State:** OPEN
**Title:** Summarize: help entry + structured logging

## Body
## Parent

#40

## What to build

Polish the summarize feature with discoverability and minimal observability: add a help entry and structured logs for summarize runs (without logging full page text).

## Acceptance criteria

- [ ] Help output includes `summarize|summarise <url> [extra]` description
- [ ] Summarize runs emit a single structured log line containing host, HTTP status, extracted length, duration, model/provider, and outcome
- [ ] Logs do not include full article text or other sensitive payloads

## Blocked by

- Blocked by #42