### PR TITLE
feat: Summarize: manual eval harness (fixtures + gold facts + sc… (#45)

### DIFF
--- a/eval/summarize/fixtures/pangolin.fixture.json
+++ b/eval/summarize/fixtures/pangolin.fixture.json
@@ -1,0 +1,9 @@
+{
+  "id": "pangolin-2026",
+  "metadata": {
+    "title": "The secret life of pangolins",
+    "sourceUrl": "https://example.com/news/pangolins",
+    "note": "Offline copy of text produced by extractArticleTextFromHtml on test/fixtures/summarize/article.html"
+  },
+  "extractedText": "The secret life of pangolins Pangolins are scaly mammals found in Asia and Africa. They eat ants and termites using long sticky tongues. Despite international protection, they remain under heavy pressure from illegal trafficking. Conservation groups track populations and run shipments interdiction programs across many borders. Researchers also study their role in forest soil health because their burrowing mixes organic matter into the ground. This article walks through field surveys, genetic sampling, and community education efforts that aim to reduce demand for scales and meat. None of this is medical advice; it is only background for curious readers who want a plain-language overview before deeper reading. In the second half we outline a simple mental model for why enforcement alone is not enough without reducing consumer myths. Volunteers document sightings with phones and shared maps, which helps biologists understand movement corridors. Meanwhile, rescue centers rehabilitate injured animals when possible and release them where habitat remains. The text continues with enough sentences to exceed heuristic length thresholds used by extractors so automated tests have realistic material that resembles a news article body."
+}

--- a/eval/summarize/gold/pangolin.gold.json
+++ b/eval/summarize/gold/pangolin.gold.json
@@ -1,0 +1,17 @@
+{
+  "fixtureId": "pangolin-2026",
+  "facts": [
+    {
+      "id": "range",
+      "acceptableEvidenceSubstrings": ["Asia and Africa"]
+    },
+    {
+      "id": "diet",
+      "acceptableEvidenceSubstrings": ["ants and termites"]
+    },
+    {
+      "id": "trafficking_pressure",
+      "acceptableEvidenceSubstrings": ["illegal trafficking"]
+    }
+  ]
+}

--- a/eval/summarize/lib/buildEvalPrompt.js
+++ b/eval/summarize/lib/buildEvalPrompt.js
@@ -1,0 +1,27 @@
+/**
+ * Prompt asking for strict JSON with grounded bullets (same spirit as WhatsApp summarize).
+ * @param {string} extractedText (possibly truncated)
+ * @param {string} [extraFocus] optional user focus, like summarize “extra” tail
+ */
+export function buildSummarizeEvalPrompt(extractedText, extraFocus = '') {
+  const focus = String(extraFocus || '').trim() || 'None.';
+  return [
+    'You summarize text extracted from a web page for a short evaluation run.',
+    'Rules:',
+    '- Be accurate; do not invent facts.',
+    '- Output MUST be a single JSON object and nothing else (no markdown fences, no commentary).',
+    '- The object MUST have key "bullets" whose value is an array.',
+    '- Each bullet MUST be an object with:',
+    '  - "text": a short summary point.',
+    '  - "evidence_quote": a verbatim substring copied from the extracted article text below (copy-paste, not paraphrased).',
+    '- Every evidence_quote MUST appear exactly as a contiguous substring in the extracted article text.',
+    '',
+    'Optional user focus:',
+    focus,
+    '',
+    'Extracted article text:',
+    '---',
+    String(extractedText),
+    '---',
+  ].join('\n');
+}

--- a/eval/summarize/lib/loadFiles.js
+++ b/eval/summarize/lib/loadFiles.js
@@ -36,20 +36,74 @@ export function loadGold(absPath) {
 
 /**
  * Pair `stem.fixture.json` with `stem.gold.json` under the given roots.
+ * Every `*.fixture.json` must have a same-stem `*.gold.json`, and vice versa.
  * @param {string} fixturesDir
  * @param {string} goldsDir
+ * @throws {Error} when directories are unreadable or the fixture/gold sets disagree
  */
 export function listFixtureGoldPairs(fixturesDir, goldsDir) {
-  const names = readdirSync(fixturesDir);
-  /** @type {Array<{ stem: string; fixturePath: string; goldPath: string }>} */
-  const out = [];
-  for (const name of names) {
+  let fixtureNames;
+  let goldNames;
+  try {
+    fixtureNames = readdirSync(fixturesDir);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Cannot read fixtures directory ${fixturesDir}: ${msg}`);
+  }
+  try {
+    goldNames = readdirSync(goldsDir);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Cannot read gold directory ${goldsDir}: ${msg}`);
+  }
+
+  /** @type {Map<string, string>} stem -> fixture filename */
+  const fixtureByStem = new Map();
+  for (const name of fixtureNames) {
     const m = /^(.+)\.fixture\.json$/.exec(name);
     if (!m) continue;
-    const stem = m[1];
+    fixtureByStem.set(m[1], name);
+  }
+
+  /** @type {Set<string>} */
+  const goldStems = new Set();
+  for (const name of goldNames) {
+    const m = /^(.+)\.gold\.json$/.exec(name);
+    if (!m) continue;
+    goldStems.add(m[1]);
+  }
+
+  /** @type {string[]} */
+  const problems = [];
+  for (const stem of fixtureByStem.keys()) {
+    if (!goldStems.has(stem)) {
+      problems.push(
+        `missing gold: "${stem}.fixture.json" in ${fixturesDir} has no matching "${stem}.gold.json" in ${goldsDir}`,
+      );
+    }
+  }
+  for (const stem of goldStems) {
+    if (!fixtureByStem.has(stem)) {
+      problems.push(
+        `orphan gold: "${stem}.gold.json" in ${goldsDir} has no matching "${stem}.fixture.json" in ${fixturesDir}`,
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Fixture/gold pairing is inconsistent (${problems.length} issue(s)):\n- ${problems.join('\n- ')}`,
+    );
+  }
+
+  /** @type {Array<{ stem: string; fixturePath: string; goldPath: string }>} */
+  const out = [];
+  for (const [stem, name] of fixtureByStem) {
     const fixturePath = path.join(fixturesDir, name);
     const goldPath = path.join(goldsDir, `${stem}.gold.json`);
     out.push({ stem, fixturePath, goldPath });
   }
+
+  out.sort((a, b) => a.stem.localeCompare(b.stem));
   return out;
 }

--- a/eval/summarize/lib/loadFiles.js
+++ b/eval/summarize/lib/loadFiles.js
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * @param {string} absPath
+ * @returns {import('./types.js').SummarizeEvalFixture}
+ */
+export function loadFixture(absPath) {
+  const raw = readFileSync(absPath, 'utf8');
+  const j = JSON.parse(raw);
+  if (j == null || typeof j !== 'object' || typeof /** @type {any} */ (j).id !== 'string') {
+    throw new Error(`Invalid fixture (missing id): ${absPath}`);
+  }
+  if (typeof /** @type {any} */ (j).extractedText !== 'string') {
+    throw new Error(`Invalid fixture (extractedText must be string): ${absPath}`);
+  }
+  return /** @type {import('./types.js').SummarizeEvalFixture} */ (j);
+}
+
+/**
+ * @param {string} absPath
+ * @returns {import('./types.js').SummarizeEvalGold}
+ */
+export function loadGold(absPath) {
+  const raw = readFileSync(absPath, 'utf8');
+  const j = JSON.parse(raw);
+  if (j == null || typeof j !== 'object' || typeof /** @type {any} */ (j).fixtureId !== 'string') {
+    throw new Error(`Invalid gold file (missing fixtureId): ${absPath}`);
+  }
+  const facts = /** @type {any} */ (j).facts;
+  if (!Array.isArray(facts)) {
+    throw new Error(`Invalid gold file (facts must be array): ${absPath}`);
+  }
+  return /** @type {import('./types.js').SummarizeEvalGold} */ (j);
+}
+
+/**
+ * Pair `stem.fixture.json` with `stem.gold.json` under the given roots.
+ * @param {string} fixturesDir
+ * @param {string} goldsDir
+ */
+export function listFixtureGoldPairs(fixturesDir, goldsDir) {
+  const names = readdirSync(fixturesDir);
+  /** @type {Array<{ stem: string; fixturePath: string; goldPath: string }>} */
+  const out = [];
+  for (const name of names) {
+    const m = /^(.+)\.fixture\.json$/.exec(name);
+    if (!m) continue;
+    const stem = m[1];
+    const fixturePath = path.join(fixturesDir, name);
+    const goldPath = path.join(goldsDir, `${stem}.gold.json`);
+    out.push({ stem, fixturePath, goldPath });
+  }
+  return out;
+}

--- a/eval/summarize/lib/maxInputChars.js
+++ b/eval/summarize/lib/maxInputChars.js
@@ -1,0 +1,11 @@
+/** Matches `SUMMARIZE_MAX_INPUT_CHARS` / cap used by the live summarize command. */
+export function maxLlmInputChars() {
+  const n = parseInt(process.env.SUMMARIZE_MAX_INPUT_CHARS || '24000', 10);
+  return Number.isFinite(n) && n > 0 ? Math.min(n, 500_000) : 24_000;
+}
+
+export function truncateExtractedText(extractedText, cap = maxLlmInputChars()) {
+  const s = String(extractedText ?? '');
+  if (s.length <= cap) return s;
+  return `${s.slice(0, cap)}\n\n[… truncated for model input length …]`;
+}

--- a/eval/summarize/lib/runEval.js
+++ b/eval/summarize/lib/runEval.js
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs';
 import { buildSummarizeEvalPrompt } from './buildEvalPrompt.js';
 import { truncateExtractedText } from './maxInputChars.js';
 import { validateSummarizeEvalJson } from './validateModelOutput.js';
@@ -78,22 +77,6 @@ export async function runSummarizeEvalAll(opts) {
   let coveredFacts = 0;
 
   for (const p of opts.pairs) {
-    if (!existsSync(p.goldPath)) {
-      runs.push({
-        fixtureId: p.stem,
-        stem: p.stem,
-        model: opts.model,
-        temperature: opts.temperature ?? null,
-        rawModelOutput: '',
-        validation: {
-          ok: false,
-          errors: [`Missing gold file for stem "${p.stem}": ${p.goldPath}`],
-        },
-        coverage: null,
-      });
-      continue;
-    }
-
     const one = await runSummarizeEvalOnce({
       fixturePath: p.fixturePath,
       goldPath: p.goldPath,

--- a/eval/summarize/lib/runEval.js
+++ b/eval/summarize/lib/runEval.js
@@ -1,0 +1,128 @@
+import { existsSync } from 'node:fs';
+import { buildSummarizeEvalPrompt } from './buildEvalPrompt.js';
+import { truncateExtractedText } from './maxInputChars.js';
+import { validateSummarizeEvalJson } from './validateModelOutput.js';
+import { scoreGoldAgainstOutput } from './scoreGold.js';
+import { loadFixture, loadGold } from './loadFiles.js';
+
+/**
+ * @param {{
+ *   fixturePath: string;
+ *   goldPath: string;
+ *   model: string;
+ *   temperature?: number;
+ *   extraFocus?: string;
+ *   deepInfraAPI: typeof import('../../../models/models.js').deepInfraAPI;
+ *   signal?: AbortSignal;
+ * }} opts
+ */
+export async function runSummarizeEvalOnce(opts) {
+  const fixture = loadFixture(opts.fixturePath);
+  const gold = loadGold(opts.goldPath);
+
+  if (gold.fixtureId !== fixture.id) {
+    throw new Error(
+      `Gold fixtureId "${gold.fixtureId}" does not match fixture id "${fixture.id}"`,
+    );
+  }
+
+  const forModel = truncateExtractedText(fixture.extractedText);
+  const prompt = buildSummarizeEvalPrompt(forModel, opts.extraFocus ?? '');
+
+  const raw = await opts.deepInfraAPI(prompt, opts.model, {
+    temperature: opts.temperature,
+    signal: opts.signal,
+  });
+
+  const rawString = typeof raw === 'string' ? raw : String(raw ?? '');
+  const validation = validateSummarizeEvalJson(rawString, fixture.extractedText);
+
+  if (!validation.ok) {
+    return {
+      fixtureId: fixture.id,
+      model: opts.model,
+      temperature: opts.temperature ?? null,
+      rawModelOutput: rawString,
+      validation,
+      coverage: null,
+    };
+  }
+
+  const coverage = scoreGoldAgainstOutput(validation.value, gold);
+
+  return {
+    fixtureId: fixture.id,
+    model: opts.model,
+    temperature: opts.temperature ?? null,
+    rawModelOutput: rawString,
+    validation,
+    coverage,
+  };
+}
+
+/**
+ * @param {{
+ *   pairs: Array<{ stem: string; fixturePath: string; goldPath: string }>;
+ *   model: string;
+ *   temperature?: number;
+ *   extraFocus?: string;
+ *   deepInfraAPI: typeof import('../../../models/models.js').deepInfraAPI;
+ *   signal?: AbortSignal;
+ * }} opts
+ */
+export async function runSummarizeEvalAll(opts) {
+  /** @type {Awaited<ReturnType<typeof runSummarizeEvalOnce>>[]} */
+  const runs = [];
+
+  let totalFacts = 0;
+  let coveredFacts = 0;
+
+  for (const p of opts.pairs) {
+    if (!existsSync(p.goldPath)) {
+      runs.push({
+        fixtureId: p.stem,
+        stem: p.stem,
+        model: opts.model,
+        temperature: opts.temperature ?? null,
+        rawModelOutput: '',
+        validation: {
+          ok: false,
+          errors: [`Missing gold file for stem "${p.stem}": ${p.goldPath}`],
+        },
+        coverage: null,
+      });
+      continue;
+    }
+
+    const one = await runSummarizeEvalOnce({
+      fixturePath: p.fixturePath,
+      goldPath: p.goldPath,
+      model: opts.model,
+      temperature: opts.temperature,
+      extraFocus: opts.extraFocus,
+      deepInfraAPI: opts.deepInfraAPI,
+      signal: opts.signal,
+    });
+
+    runs.push({
+      ...one,
+      stem: p.stem,
+    });
+
+    if (one.coverage) {
+      totalFacts += one.coverage.totalFacts;
+      coveredFacts += one.coverage.coveredFacts;
+    }
+  }
+
+  const overallPercent = totalFacts === 0 ? 100 : (coveredFacts / totalFacts) * 100;
+
+  return {
+    runs,
+    overall: {
+      totalFacts,
+      coveredFacts,
+      percent: overallPercent,
+    },
+  };
+}

--- a/eval/summarize/lib/scoreGold.js
+++ b/eval/summarize/lib/scoreGold.js
@@ -1,0 +1,76 @@
+/**
+ * A fact is covered if some bullet's evidence_quote satisfies the gold entry.
+ *
+ * - mode `any` (default): at least one string in acceptableEvidenceSubstrings appears as a substring of some evidence_quote.
+ * - mode `all`: every string in acceptableEvidenceSubstrings appears as a substring of the same evidence_quote.
+ *
+ * @param {import('./types.js').SummarizeEvalOutput} output
+ * @param {import('./types.js').SummarizeEvalGold} gold
+ */
+export function scoreGoldAgainstOutput(output, gold) {
+  const bullets = Array.isArray(output.bullets) ? output.bullets : [];
+  /** @type {Array<{ id: string; covered: boolean; detail: string }>} */
+  const facts = [];
+
+  for (const f of gold.facts || []) {
+    const mode = f.mode === 'all' ? 'all' : 'any';
+    const subs = Array.isArray(f.acceptableEvidenceSubstrings)
+      ? f.acceptableEvidenceSubstrings.map((s) => String(s))
+      : [];
+
+    if (subs.length === 0) {
+      facts.push({
+        id: f.id,
+        covered: false,
+        detail: 'no acceptableEvidenceSubstrings defined',
+      });
+      continue;
+    }
+
+    let covered = false;
+    let detail = '';
+
+    if (mode === 'any') {
+      for (const sub of subs) {
+        for (const b of bullets) {
+          if (typeof b.evidence_quote === 'string' && b.evidence_quote.includes(sub)) {
+            covered = true;
+            detail = `matched substring for "${f.id}" in evidence_quote`;
+            break;
+          }
+        }
+        if (covered) break;
+      }
+      if (!covered) {
+        detail = 'no acceptable substring found in any evidence_quote';
+      }
+    } else {
+      for (const b of bullets) {
+        const q = b.evidence_quote;
+        if (typeof q !== 'string') continue;
+        const ok = subs.every((sub) => q.includes(sub));
+        if (ok) {
+          covered = true;
+          detail = `all required substrings found in one evidence_quote`;
+          break;
+        }
+      }
+      if (!covered) {
+        detail = 'no single evidence_quote contains all required substrings';
+      }
+    }
+
+    facts.push({ id: f.id, covered, detail });
+  }
+
+  const totalFacts = facts.length;
+  const coveredFacts = facts.filter((x) => x.covered).length;
+  const percent = totalFacts === 0 ? 100 : (coveredFacts / totalFacts) * 100;
+
+  return {
+    facts,
+    totalFacts,
+    coveredFacts,
+    percent,
+  };
+}

--- a/eval/summarize/lib/types.js
+++ b/eval/summarize/lib/types.js
@@ -1,0 +1,25 @@
+/**
+ * @typedef {{ text: string; evidence_quote: string }} SummarizeEvalBullet
+ * @typedef {{ bullets: SummarizeEvalBullet[] }} SummarizeEvalOutput
+ */
+
+/**
+ * @typedef {{
+ *   id: string;
+ *   metadata?: Record<string, unknown>;
+ *   extractedText: string;
+ * }} SummarizeEvalFixture
+ */
+
+/**
+ * @typedef {{
+ *   fixtureId: string;
+ *   facts: Array<{
+ *     id: string;
+ *     acceptableEvidenceSubstrings: string[];
+ *     mode?: 'any' | 'all';
+ *   }>;
+ * }} SummarizeEvalGold
+ */
+
+export {};

--- a/eval/summarize/lib/validateModelOutput.js
+++ b/eval/summarize/lib/validateModelOutput.js
@@ -1,0 +1,78 @@
+/**
+ * Strip optional ```json ... ``` fences from model output.
+ * @param {string} raw
+ */
+export function stripMarkdownJsonFence(raw) {
+  let s = String(raw ?? '').trim();
+  const fence = /^```(?:json)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/i.exec(s);
+  if (fence) s = fence[1].trim();
+  return s;
+}
+
+/**
+ * @typedef {{ text: string; evidence_quote: string }} SummarizeEvalBullet
+ * @typedef {{ bullets: SummarizeEvalBullet[] }} SummarizeEvalOutput
+ */
+
+/**
+ * @param {string} rawModelString
+ * @param {string} fixtureExtractedText verbatim fixture text (substring checks use raw strings)
+ * @returns {{ ok: true; value: SummarizeEvalOutput } | { ok: false; errors: string[] }}
+ */
+export function validateSummarizeEvalJson(rawModelString, fixtureExtractedText) {
+  const errors = [];
+  let parsed;
+  const stripped = stripMarkdownJsonFence(rawModelString);
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, errors: [`Invalid JSON: ${msg}`] };
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, errors: ['Root JSON value must be a non-null object.'] };
+  }
+
+  const bullets = /** @type {unknown} */ (/** @type {Record<string, unknown>} */ (parsed).bullets);
+  if (!Array.isArray(bullets)) {
+    return { ok: false, errors: ['Missing or invalid "bullets" array.'] };
+  }
+
+  const article = String(fixtureExtractedText ?? '');
+  /** @type {SummarizeEvalBullet[]} */
+  const out = [];
+
+  for (let i = 0; i < bullets.length; i++) {
+    const b = bullets[i];
+    if (b === null || typeof b !== 'object' || Array.isArray(b)) {
+      errors.push(`bullets[${i}] must be an object.`);
+      continue;
+    }
+    const rec = /** @type {Record<string, unknown>} */ (b);
+    const text = rec.text;
+    const evidenceQuote = rec.evidence_quote;
+    if (typeof text !== 'string') {
+      errors.push(`bullets[${i}].text must be a string.`);
+    }
+    if (typeof evidenceQuote !== 'string') {
+      errors.push(`bullets[${i}].evidence_quote must be a string.`);
+    }
+    if (typeof evidenceQuote === 'string') {
+      if (!article.includes(evidenceQuote)) {
+        errors.push(
+          `bullets[${i}].evidence_quote is not a substring of the fixture extracted text.`,
+        );
+      }
+    }
+    if (typeof text === 'string' && typeof evidenceQuote === 'string' && article.includes(evidenceQuote)) {
+      out.push({ text, evidence_quote: evidenceQuote });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, value: { bullets: out } };
+}

--- a/eval/summarize/run.mjs
+++ b/eval/summarize/run.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Manual summarize eval runner: offline fixture text + gold facts, optional DeepInfra call.
+ *
+ * Usage:
+ *   node eval/summarize/run.mjs --fixture eval/summarize/fixtures/pangolin.fixture.json \\
+ *     --gold eval/summarize/gold/pangolin.gold.json --model deepseek-ai/DeepSeek-V3 --temperature 0.2
+ *
+ *   node eval/summarize/run.mjs --all --model deepseek-ai/DeepSeek-V3
+ *
+ * Requires DEEPINFRA_API_KEY for live runs. Tests mock the API and do not need network.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+import { deepInfraAPI, DEEPINFRA_DEFAULT_CHAT_MODEL } from '../../models/models.js';
+import { listFixtureGoldPairs } from './lib/loadFiles.js';
+import { runSummarizeEvalOnce, runSummarizeEvalAll } from './lib/runEval.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const defaultFixturesDir = path.join(__dirname, 'fixtures');
+const defaultGoldsDir = path.join(__dirname, 'gold');
+
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--all') {
+      out.all = true;
+      continue;
+    }
+    if (a.startsWith('--')) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        out[key] = true;
+      } else {
+        out[key] = next;
+        i++;
+      }
+    }
+  }
+  return out;
+}
+
+function printRun(/** @type {any} */ r) {
+  console.log(`\n--- fixture: ${r.fixtureId} (${r.stem ?? 'single'}) ---`);
+  console.log(`model: ${r.model}  temperature: ${r.temperature ?? 'default'}`);
+  if (!r.validation.ok) {
+    console.log('validation: FAIL');
+    for (const e of r.validation.errors) console.log(`  - ${e}`);
+    return;
+  }
+  console.log('validation: OK (JSON + evidence_quote substrings of fixture text)');
+  if (r.coverage) {
+    console.log(
+      `fact coverage: ${r.coverage.coveredFacts}/${r.coverage.totalFacts} (${r.coverage.percent.toFixed(1)}%)`,
+    );
+    for (const f of r.coverage.facts) {
+      console.log(`  - [${f.covered ? 'x' : ' '}] ${f.id}: ${f.detail}`);
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const all = args.all === true;
+  const fixture = typeof args.fixture === 'string' ? args.fixture : null;
+  const gold = typeof args.gold === 'string' ? args.gold : null;
+  const model =
+    typeof args.model === 'string' ? args.model : DEEPINFRA_DEFAULT_CHAT_MODEL;
+  const extraFocus = typeof args.extra === 'string' ? args.extra : '';
+
+  let tempOpt = undefined;
+  if (typeof args.temperature === 'string') {
+    const t = parseFloat(args.temperature);
+    if (Number.isFinite(t)) tempOpt = t;
+  }
+
+  if (!process.env.DEEPINFRA_API_KEY) {
+    console.error('DEEPINFRA_API_KEY is not set; cannot call the model.');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (all) {
+    const fixturesDir =
+      typeof args['fixtures-dir'] === 'string' ? args['fixtures-dir'] : defaultFixturesDir;
+    const goldsDir = typeof args['golds-dir'] === 'string' ? args['golds-dir'] : defaultGoldsDir;
+    const pairs = listFixtureGoldPairs(path.resolve(fixturesDir), path.resolve(goldsDir));
+    if (pairs.length === 0) {
+      console.error(`No *.fixture.json files in ${fixturesDir}`);
+      process.exitCode = 1;
+      return;
+    }
+    const result = await runSummarizeEvalAll({
+      pairs,
+      model,
+      temperature: tempOpt,
+      extraFocus,
+      deepInfraAPI,
+    });
+    for (const r of result.runs) printRun(r);
+    console.log('\n=== overall (validated runs only) ===');
+    console.log(
+      `facts: ${result.overall.coveredFacts}/${result.overall.totalFacts} (${result.overall.percent.toFixed(1)}%)`,
+    );
+    return;
+  }
+
+  if (fixture && gold) {
+    const r = await runSummarizeEvalOnce({
+      fixturePath: path.resolve(fixture),
+      goldPath: path.resolve(gold),
+      model,
+      temperature: tempOpt,
+      extraFocus,
+      deepInfraAPI,
+    });
+    printRun({ ...r, stem: 'single' });
+    if (r.validation.ok && r.coverage) {
+      console.log('\n=== summary ===');
+      console.log(
+        `fact coverage: ${r.coverage.coveredFacts}/${r.coverage.totalFacts} (${r.coverage.percent.toFixed(1)}%)`,
+      );
+    }
+    return;
+  }
+
+  console.error(
+    'Provide --fixture and --gold, or use --all (see eval/summarize/run.mjs header comment).',
+  );
+  process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.stack || e.message : e);
+  process.exitCode = 1;
+});

--- a/eval/summarize/run.mjs
+++ b/eval/summarize/run.mjs
@@ -8,7 +8,8 @@
  *
  *   node eval/summarize/run.mjs --all --model deepseek-ai/DeepSeek-V3
  *
- * Requires DEEPINFRA_API_KEY for live runs. Tests mock the API and do not need network.
+ * DEEPINFRA_API_KEY is required only when this script calls the live DeepInfra API (pairing and
+ * directory checks run without it). Tests mock the API and do not need network or a key.
  */
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -76,12 +77,6 @@ async function main() {
   if (typeof args.temperature === 'string') {
     const t = parseFloat(args.temperature);
     if (Number.isFinite(t)) tempOpt = t;
-  }
-
-  if (!process.env.DEEPINFRA_API_KEY) {
-    console.error('DEEPINFRA_API_KEY is not set; cannot call the model.');
-    process.exitCode = 1;
-    return;
   }
 
   if (all) {

--- a/models/models.js
+++ b/models/models.js
@@ -69,10 +69,11 @@ export async function deepInfraAPI(
   model = DEEPINFRA_DEFAULT_CHAT_MODEL,
   options = {},
 ) {
-  const { signal } = options;
+  const { signal, temperature } = options;
   const completion = await deepInfra.chat.completions.create({
     messages: [{ role: 'user', content }],
     model,
+    ...(temperature !== undefined && temperature !== null ? { temperature } : {}),
     ...(signal !== undefined ? { signal } : {}),
   });
 

--- a/models/models.js
+++ b/models/models.js
@@ -64,18 +64,33 @@ export const deepInfra = new OpenAI({
 /** Default chat model for `deepInfraAPI` when `model` is omitted. */
 export const DEEPINFRA_DEFAULT_CHAT_MODEL = 'deepseek-ai/DeepSeek-V3';
 
+/**
+ * Build the body passed to `deepInfra.chat.completions.create` (pure; used by tests for option plumbing).
+ * @param {string} content
+ * @param {string} model
+ * @param {{ signal?: AbortSignal; temperature?: number | null }} [options]
+ */
+export function buildDeepInfraCompletionCreateArgs(content, model, options = {}) {
+  const { signal, temperature } = options;
+  return {
+    messages: [{ role: 'user', content }],
+    model,
+    ...(temperature !== undefined && temperature !== null ? { temperature } : {}),
+    ...(signal !== undefined ? { signal } : {}),
+  };
+}
+
 export async function deepInfraAPI(
   content,
   model = DEEPINFRA_DEFAULT_CHAT_MODEL,
   options = {},
 ) {
-  const { signal, temperature } = options;
-  const completion = await deepInfra.chat.completions.create({
-    messages: [{ role: 'user', content }],
-    model,
-    ...(temperature !== undefined && temperature !== null ? { temperature } : {}),
-    ...(signal !== undefined ? { signal } : {}),
-  });
+  if (!process.env.DEEPINFRA_API_KEY?.trim()) {
+    throw new Error('DEEPINFRA_API_KEY is not set; cannot call the DeepInfra chat model.');
+  }
+  const completion = await deepInfra.chat.completions.create(
+    buildDeepInfraCompletionCreateArgs(content, model, options),
+  );
 
   console.log(completion.usage.prompt_tokens, completion.usage.completion_tokens);
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test ./test/**/*.test.js",
+    "eval:summarize": "node eval/summarize/run.mjs",
     "start": "node --no-deprecation whatsapp.js",
     "start:joplin": "node --no-deprecation test-joplin.js"
   },

--- a/test/deepInfraCompletionParams.test.js
+++ b/test/deepInfraCompletionParams.test.js
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildDeepInfraCompletionCreateArgs,
+  DEEPINFRA_DEFAULT_CHAT_MODEL,
+} from '../models/models.js';
+
+describe('buildDeepInfraCompletionCreateArgs', () => {
+  it('forwards temperature into the completion request body', () => {
+    const body = buildDeepInfraCompletionCreateArgs('hello', 'my/model', { temperature: 0.35 });
+    assert.equal(body.model, 'my/model');
+    assert.deepEqual(body.messages, [{ role: 'user', content: 'hello' }]);
+    assert.equal(body.temperature, 0.35);
+  });
+
+  it('omits temperature when option is undefined or null', () => {
+    const u = buildDeepInfraCompletionCreateArgs('x', DEEPINFRA_DEFAULT_CHAT_MODEL, {});
+    assert.ok(!('temperature' in u));
+    const n = buildDeepInfraCompletionCreateArgs('x', DEEPINFRA_DEFAULT_CHAT_MODEL, {
+      temperature: null,
+    });
+    assert.ok(!('temperature' in n));
+  });
+
+  it('includes AbortSignal when passed in options', () => {
+    const ac = new AbortController();
+    const body = buildDeepInfraCompletionCreateArgs('x', DEEPINFRA_DEFAULT_CHAT_MODEL, {
+      signal: ac.signal,
+      temperature: 0,
+    });
+    assert.equal(body.signal, ac.signal);
+    assert.equal(body.temperature, 0);
+  });
+});

--- a/test/summarizeEval.test.js
+++ b/test/summarizeEval.test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -7,6 +9,7 @@ import {
   validateSummarizeEvalJson,
 } from '../eval/summarize/lib/validateModelOutput.js';
 import { scoreGoldAgainstOutput } from '../eval/summarize/lib/scoreGold.js';
+import { listFixtureGoldPairs } from '../eval/summarize/lib/loadFiles.js';
 import { runSummarizeEvalOnce, runSummarizeEvalAll } from '../eval/summarize/lib/runEval.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -55,6 +58,35 @@ describe('validateSummarizeEvalJson', () => {
     const v = validateSummarizeEvalJson('not json', FIXTURE_TEXT);
     assert.equal(v.ok, false);
   });
+
+  it('rejects bullets missing evidence_quote', () => {
+    const raw = JSON.stringify({
+      bullets: [{ text: 'only text' }],
+    });
+    const v = validateSummarizeEvalJson(raw, FIXTURE_TEXT);
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.ok(v.errors.some((e) => e.includes('evidence_quote')), JSON.stringify(v.errors));
+    }
+  });
+
+  it('rejects malformed bullet entries that are not objects', () => {
+    const raw = JSON.stringify({ bullets: ['not an object'] });
+    const v = validateSummarizeEvalJson(raw, FIXTURE_TEXT);
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.ok(v.errors.some((e) => e.includes('must be an object')), JSON.stringify(v.errors));
+    }
+  });
+
+  it('accepts JSON wrapped in a markdown ```json fence', () => {
+    const inner = JSON.stringify({
+      bullets: [{ text: 't', evidence_quote: 'Alpha evidence' }],
+    });
+    const fenced = '```json\n' + inner + '\n```';
+    const v = validateSummarizeEvalJson(fenced, FIXTURE_TEXT);
+    assert.equal(v.ok, true);
+  });
 });
 
 describe('scoreGoldAgainstOutput', () => {
@@ -102,6 +134,57 @@ describe('scoreGoldAgainstOutput', () => {
     };
     const sBad = scoreGoldAgainstOutput(split, goldAll);
     assert.equal(sBad.coveredFacts, 0);
+  });
+});
+
+describe('listFixtureGoldPairs', () => {
+  it('throws when a fixture file has no matching gold file', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'ev-fix-'));
+    const fixtures = path.join(root, 'fx');
+    const golds = path.join(root, 'gd');
+    mkdirSync(fixtures);
+    mkdirSync(golds);
+    writeFileSync(
+      path.join(fixtures, 'a.fixture.json'),
+      JSON.stringify({ id: 'a', extractedText: 'x' }),
+    );
+    assert.throws(() => listFixtureGoldPairs(fixtures, golds), /missing gold|inconsistent/);
+  });
+
+  it('throws when a gold file has no matching fixture', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'ev-gold-'));
+    const fixtures = path.join(root, 'fx');
+    const golds = path.join(root, 'gd');
+    mkdirSync(fixtures);
+    mkdirSync(golds);
+    writeFileSync(
+      path.join(golds, 'orphan.gold.json'),
+      JSON.stringify({ fixtureId: 'orphan', facts: [] }),
+    );
+    assert.throws(() => listFixtureGoldPairs(fixtures, golds), /orphan gold|inconsistent/);
+  });
+
+  it('returns sorted pairs when fixture and gold stems match', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'ev-pair-'));
+    const fixtures = path.join(root, 'fx');
+    const golds = path.join(root, 'gd');
+    mkdirSync(fixtures);
+    mkdirSync(golds);
+    writeFileSync(
+      path.join(fixtures, 'b.fixture.json'),
+      JSON.stringify({ id: 'b', extractedText: 'x' }),
+    );
+    writeFileSync(
+      path.join(fixtures, 'a.fixture.json'),
+      JSON.stringify({ id: 'a', extractedText: 'y' }),
+    );
+    writeFileSync(path.join(golds, 'b.gold.json'), JSON.stringify({ fixtureId: 'b', facts: [] }));
+    writeFileSync(path.join(golds, 'a.gold.json'), JSON.stringify({ fixtureId: 'a', facts: [] }));
+    const pairs = listFixtureGoldPairs(fixtures, golds);
+    assert.deepEqual(
+      pairs.map((p) => p.stem),
+      ['a', 'b'],
+    );
   });
 });
 
@@ -180,5 +263,53 @@ describe('runSummarizeEvalOnce (mocked LLM, no network)', () => {
     assert.equal(result.overall.coveredFacts, 3);
     assert.equal(result.runs.length, 1);
     assert.equal(result.runs[0].validation.ok, true);
+  });
+
+  it('runSummarizeEvalAll propagates when gold file path does not exist', async () => {
+    /** @type {typeof import('../models/models.js').deepInfraAPI} */
+    async function fakeLlm() {
+      return '{}';
+    }
+    await assert.rejects(
+      runSummarizeEvalAll({
+        pairs: [
+          {
+            stem: 'missing',
+            fixturePath: pangolinFixture,
+            goldPath: path.join(here, 'nonexistent-dir', 'nope.gold.json'),
+          },
+        ],
+        model: 'test/model',
+        deepInfraAPI: fakeLlm,
+      }),
+      /ENOENT|no such file/i,
+    );
+  });
+
+  it('runSummarizeEvalOnce throws when gold fixtureId mismatches fixture id', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'ev-mismatch-'));
+    const badGold = path.join(root, 'wrong.gold.json');
+    writeFileSync(
+      badGold,
+      JSON.stringify({
+        fixtureId: 'not-pangolin',
+        facts: [],
+      }),
+    );
+
+    /** @type {typeof import('../models/models.js').deepInfraAPI} */
+    async function fakeLlm() {
+      return '{}';
+    }
+
+    await assert.rejects(
+      runSummarizeEvalOnce({
+        fixturePath: pangolinFixture,
+        goldPath: badGold,
+        model: 'm',
+        deepInfraAPI: fakeLlm,
+      }),
+      /does not match fixture id/,
+    );
   });
 });

--- a/test/summarizeEval.test.js
+++ b/test/summarizeEval.test.js
@@ -1,0 +1,184 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  stripMarkdownJsonFence,
+  validateSummarizeEvalJson,
+} from '../eval/summarize/lib/validateModelOutput.js';
+import { scoreGoldAgainstOutput } from '../eval/summarize/lib/scoreGold.js';
+import { runSummarizeEvalOnce, runSummarizeEvalAll } from '../eval/summarize/lib/runEval.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pangolinFixture = path.join(here, '..', 'eval', 'summarize', 'fixtures', 'pangolin.fixture.json');
+const pangolinGold = path.join(here, '..', 'eval', 'summarize', 'gold', 'pangolin.gold.json');
+
+const FIXTURE_TEXT =
+  'Alpha evidence about bravo. Charlie and delta appear in one sentence together.';
+
+describe('stripMarkdownJsonFence', () => {
+  it('removes a fenced JSON block', () => {
+    const inner = '{"bullets":[]}';
+    const wrapped = '```json\n' + inner + '\n```';
+    assert.equal(stripMarkdownJsonFence(wrapped), inner);
+  });
+});
+
+describe('validateSummarizeEvalJson', () => {
+  it('accepts valid bullets with grounded evidence_quote', () => {
+    const raw = JSON.stringify({
+      bullets: [
+        { text: 't', evidence_quote: 'Alpha evidence' },
+        { text: 'u', evidence_quote: 'Charlie and delta' },
+      ],
+    });
+    const v = validateSummarizeEvalJson(raw, FIXTURE_TEXT);
+    assert.equal(v.ok, true);
+    if (v.ok) assert.equal(v.value.bullets.length, 2);
+  });
+
+  it('rejects when evidence_quote is not a substring of fixture text', () => {
+    const raw = JSON.stringify({
+      bullets: [{ text: 't', evidence_quote: 'not in article' }],
+    });
+    const v = validateSummarizeEvalJson(raw, FIXTURE_TEXT);
+    assert.equal(v.ok, false);
+    if (!v.ok) {
+      assert.ok(
+        v.errors.some((e) => e.includes('not a substring')),
+        JSON.stringify(v.errors),
+      );
+    }
+  });
+
+  it('rejects non-JSON', () => {
+    const v = validateSummarizeEvalJson('not json', FIXTURE_TEXT);
+    assert.equal(v.ok, false);
+  });
+});
+
+describe('scoreGoldAgainstOutput', () => {
+  const goldAny = {
+    fixtureId: 'x',
+    facts: [
+      {
+        id: 'f1',
+        acceptableEvidenceSubstrings: ['Asia', 'Moon'],
+      },
+    ],
+  };
+
+  it('mode any: one matching substring suffices', () => {
+    const out = {
+      bullets: [{ text: 'a', evidence_quote: 'found in Asia here' }],
+    };
+    const s = scoreGoldAgainstOutput(out, goldAny);
+    assert.equal(s.coveredFacts, 1);
+    assert.equal(s.percent, 100);
+  });
+
+  it('mode all: requires all substrings on the same evidence_quote', () => {
+    const goldAll = {
+      fixtureId: 'x',
+      facts: [
+        {
+          id: 'compound',
+          mode: 'all',
+          acceptableEvidenceSubstrings: ['Charlie', 'delta'],
+        },
+      ],
+    };
+    const ok = {
+      bullets: [{ text: 'a', evidence_quote: 'Charlie and delta appear in one sentence together.' }],
+    };
+    const sOk = scoreGoldAgainstOutput(ok, goldAll);
+    assert.equal(sOk.coveredFacts, 1);
+
+    const split = {
+      bullets: [
+        { text: 'a', evidence_quote: 'Charlie is here' },
+        { text: 'b', evidence_quote: 'delta elsewhere' },
+      ],
+    };
+    const sBad = scoreGoldAgainstOutput(split, goldAll);
+    assert.equal(sBad.coveredFacts, 0);
+  });
+});
+
+describe('runSummarizeEvalOnce (mocked LLM, no network)', () => {
+  it('scores gold facts when the model returns valid JSON', async () => {
+    const good = JSON.stringify({
+      bullets: [
+        {
+          text: 'Pangolins live in two continents.',
+          evidence_quote:
+            'Pangolins are scaly mammals found in Asia and Africa. They eat ants and termites',
+        },
+        {
+          text: 'They are threatened by trade.',
+          evidence_quote: 'illegal trafficking',
+        },
+      ],
+    });
+
+    /** @type {typeof import('../models/models.js').deepInfraAPI} */
+    async function fakeLlm() {
+      return good;
+    }
+
+    const r = await runSummarizeEvalOnce({
+      fixturePath: pangolinFixture,
+      goldPath: pangolinGold,
+      model: 'test/model',
+      temperature: 0,
+      deepInfraAPI: fakeLlm,
+    });
+
+    assert.equal(r.validation.ok, true);
+    assert.ok(r.coverage);
+    if (r.coverage) {
+      assert.equal(r.coverage.totalFacts, 3);
+      assert.equal(r.coverage.coveredFacts, 3);
+      assert.equal(r.coverage.percent, 100);
+    }
+  });
+
+  it('runSummarizeEvalAll aggregates overall fact coverage', async () => {
+    const good = JSON.stringify({
+      bullets: [
+        {
+          text: 'Pangolins live in two continents.',
+          evidence_quote:
+            'Pangolins are scaly mammals found in Asia and Africa. They eat ants and termites',
+        },
+        {
+          text: 'They are threatened by trade.',
+          evidence_quote: 'illegal trafficking',
+        },
+      ],
+    });
+
+    /** @type {typeof import('../models/models.js').deepInfraAPI} */
+    async function fakeLlm() {
+      return good;
+    }
+
+    const result = await runSummarizeEvalAll({
+      pairs: [
+        {
+          stem: 'pangolin',
+          fixturePath: pangolinFixture,
+          goldPath: pangolinGold,
+        },
+      ],
+      model: 'test/model',
+      temperature: 0,
+      deepInfraAPI: fakeLlm,
+    });
+
+    assert.equal(result.overall.totalFacts, 3);
+    assert.equal(result.overall.coveredFacts, 3);
+    assert.equal(result.runs.length, 1);
+    assert.equal(result.runs[0].validation.ok, true);
+  });
+});


### PR DESCRIPTION
Fixes #45

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-45-summarize-manual-eval-harness-fixtures-gold-fact`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #45

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/45
**State:** OPEN
**Title:** Summarize: manual eval harness (fixtures + gold facts + scoring %)

## Body
## Parent

#40

## What to build

Add an in-repo manual evaluation harness to compare models/temperatures/caps deterministically using offline fixtures (extracted article text) and gold required-facts scoring.

## Acceptance criteria

- [ ] Add fixture format that stores extracted article text and metadata (no network needed during eval runs)
- [ ] Add gold format defining required facts with acceptable evidence-quote substrings
- [ ] Add runner/tests that execute a candidate model+temperature config against fixtures
- [ ] Assertions enforced: valid JSON; bullets include `evidence_quote`; each `evidence_quote` is a substring of fixture text
- [ ] Output includes per-fixture fact coverage and overall percentage score

## Blocked by

None - can start immediately