### PR TITLE
fix: Bug: PR not being merged (#47)

### DIFF
--- a/test/cursorPostRunOrchestrator.test.js
+++ b/test/cursorPostRunOrchestrator.test.js
@@ -125,7 +125,7 @@ describe('runPostReviewAutofixMergeFlow (mocked gh + agent)', () => {
       autofixCalls++;
       return { ok: true, mergeBlocked: false, detail: 'ok' };
     };
-    const tryGhPrMergeAutoSquash = mock.fn(async () => ({ ok: true }));
+    const tryGhPrQueueAutoMerge = mock.fn(async () => ({ ok: true }));
     const tryGhPrReviewComment = mock.fn(async () => ({ ok: true }));
     const waitForGithubIssueClosed = mock.fn(async () => ({
       closed: false,
@@ -149,13 +149,13 @@ describe('runPostReviewAutofixMergeFlow (mocked gh + agent)', () => {
       pushResultOk: true,
       runSinglePostReviewAutofix,
       tryGhPrReviewComment,
-      tryGhPrMergeAutoSquash,
+      tryGhPrQueueAutoMerge,
       waitForGithubIssueClosed,
       logPost: () => {},
     });
 
     assert.equal(autofixCalls, 1);
-    assert.equal(tryGhPrMergeAutoSquash.mock.callCount(), 1);
+    assert.equal(tryGhPrQueueAutoMerge.mock.callCount(), 1);
   });
 
   it('REQUEST_CHANGES with autofix mergeBlocked skips auto-merge', async () => {
@@ -164,7 +164,7 @@ describe('runPostReviewAutofixMergeFlow (mocked gh + agent)', () => {
       mergeBlocked: true,
       detail: 'Autofix finished but **git detected no file changes**',
     });
-    const tryGhPrMergeAutoSquash = mock.fn(async () => ({ ok: true }));
+    const tryGhPrQueueAutoMerge = mock.fn(async () => ({ ok: true }));
     const tryGhPrReviewComment = mock.fn(async () => ({ ok: true }));
     const waitForGithubIssueClosed = mock.fn(async () => ({}));
 
@@ -183,18 +183,18 @@ describe('runPostReviewAutofixMergeFlow (mocked gh + agent)', () => {
       pushResultOk: true,
       runSinglePostReviewAutofix,
       tryGhPrReviewComment,
-      tryGhPrMergeAutoSquash,
+      tryGhPrQueueAutoMerge,
       waitForGithubIssueClosed,
       logPost: () => {},
     });
 
-    assert.equal(tryGhPrMergeAutoSquash.mock.callCount(), 0);
+    assert.equal(tryGhPrQueueAutoMerge.mock.callCount(), 0);
     assert.ok(tryGhPrReviewComment.mock.callCount() >= 1);
   });
 
   it('APPROVE runs auto-merge without calling autofix', async () => {
     const runSinglePostReviewAutofix = mock.fn(async () => ({ ok: true, mergeBlocked: false, detail: '' }));
-    const tryGhPrMergeAutoSquash = mock.fn(async () => ({ ok: true }));
+    const tryGhPrQueueAutoMerge = mock.fn(async () => ({ ok: true }));
     const tryGhPrReviewComment = mock.fn(async () => ({ ok: true }));
     const waitForGithubIssueClosed = mock.fn(async () => ({
       closed: false,
@@ -218,12 +218,12 @@ describe('runPostReviewAutofixMergeFlow (mocked gh + agent)', () => {
       pushResultOk: true,
       runSinglePostReviewAutofix,
       tryGhPrReviewComment,
-      tryGhPrMergeAutoSquash,
+      tryGhPrQueueAutoMerge,
       waitForGithubIssueClosed,
       logPost: () => {},
     });
 
     assert.equal(runSinglePostReviewAutofix.mock.callCount(), 0);
-    assert.equal(tryGhPrMergeAutoSquash.mock.callCount(), 1);
+    assert.equal(tryGhPrQueueAutoMerge.mock.callCount(), 1);
   });
 });

--- a/test/cursorPostRunPrMergeHelpers.test.js
+++ b/test/cursorPostRunPrMergeHelpers.test.js
@@ -1,11 +1,22 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import * as childProcess from 'node:child_process';
+import { afterEach, describe, it } from 'node:test';
 import {
+  cursorPostRunExec,
   githubPrMergeErrorLooksStaleHead,
   githubPrUpdateBranchErrorLooksNoOp,
   pickGithubMergeStrategy,
   githubMergeMethodSummaryLabel,
+  tryGhRepoMergeCapabilities,
+  tryGhPrQueueAutoMerge,
 } from '../whatsapp/agents/cursorPostRun.js';
+
+const realExecFile = childProcess.execFile.bind(childProcess);
+
+function restoreExecFile() {
+  cursorPostRunExec.execFile = (command, args, options, callback) =>
+    realExecFile(command, args, options, callback);
+}
 
 describe('PR merge / update-branch error heuristics', () => {
   it('detects stale-head auto-merge errors', () => {
@@ -57,5 +68,147 @@ describe('PR merge / update-branch error heuristics', () => {
     assert.equal(githubMergeMethodSummaryLabel('squash'), 'squash');
     assert.equal(githubMergeMethodSummaryLabel('merge'), 'merge commit');
     assert.equal(githubMergeMethodSummaryLabel('rebase'), 'rebase');
+  });
+});
+
+describe('tryGhRepoMergeCapabilities (mocked gh)', () => {
+  afterEach(() => {
+    restoreExecFile();
+  });
+
+  it('rejects non-JSON stdout with a clear error', async () => {
+    cursorPostRunExec.execFile = (cmd, args, opts, cb) => {
+      assert.equal(cmd, 'gh');
+      cb(null, 'NOTICE: extra noise\nnot-json', '');
+    };
+    const r = await tryGhRepoMergeCapabilities('/repo', 'o', 'r');
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Could not parse gh api --jq JSON/);
+  });
+
+  it('rejects jq output missing a required key', async () => {
+    cursorPostRunExec.execFile = (_cmd, _args, _opts, cb) => {
+      cb(
+        null,
+        JSON.stringify({
+          allow_squash_merge: true,
+          allow_merge_commit: true,
+          allow_rebase_merge: true,
+        }),
+        ''
+      );
+    };
+    const r = await tryGhRepoMergeCapabilities('/repo', 'o', 'r');
+    assert.equal(r.ok, false);
+    assert.match(r.error, /missing "allow_auto_merge"/);
+  });
+
+  it('rejects non-boolean allow_auto_merge (e.g. JSON null)', async () => {
+    cursorPostRunExec.execFile = (_cmd, _args, _opts, cb) => {
+      cb(
+        null,
+        JSON.stringify({
+          allow_squash_merge: false,
+          allow_merge_commit: true,
+          allow_rebase_merge: true,
+          allow_auto_merge: null,
+        }),
+        ''
+      );
+    };
+    const r = await tryGhRepoMergeCapabilities('/repo', 'o', 'r');
+    assert.equal(r.ok, false);
+    assert.match(r.error, /non-boolean allow_auto_merge/);
+  });
+
+  it('accepts exact GitHub REST-style boolean shape', async () => {
+    cursorPostRunExec.execFile = (cmd, args, opts, cb) => {
+      assert.equal(cmd, 'gh');
+      assert.deepEqual(args.slice(0, 3), ['api', 'repos/acme/widget', '--jq']);
+      cb(
+        null,
+        JSON.stringify({
+          allow_squash_merge: true,
+          allow_merge_commit: false,
+          allow_rebase_merge: false,
+          allow_auto_merge: true,
+        }),
+        ''
+      );
+    };
+    const r = await tryGhRepoMergeCapabilities('/repo', 'acme', 'widget');
+    assert.equal(r.ok, true);
+    assert.deepEqual(r, {
+      ok: true,
+      allow_squash_merge: true,
+      allow_merge_commit: false,
+      allow_rebase_merge: false,
+      allow_auto_merge: true,
+    });
+  });
+});
+
+describe('tryGhPrQueueAutoMerge (mocked gh, issue #47)', () => {
+  afterEach(() => {
+    restoreExecFile();
+  });
+
+  it('falls back to merge commit when squash is disabled but merge + auto-merge are allowed', async () => {
+    /** @type {{ cmd: string, args: string[] }[]} */
+    const calls = [];
+    cursorPostRunExec.execFile = (cmd, args, opts, cb) => {
+      calls.push({ cmd, args: [...args] });
+      const sub = args[0];
+      if (sub === 'api' && String(args[1] || '').startsWith('repos/')) {
+        cb(
+          null,
+          JSON.stringify({
+            allow_squash_merge: false,
+            allow_merge_commit: true,
+            allow_rebase_merge: true,
+            allow_auto_merge: true,
+          }),
+          ''
+        );
+        return;
+      }
+      if (sub === 'pr' && args[1] === 'merge') {
+        assert.ok(args.includes('--auto'));
+        assert.ok(args.includes('--merge'));
+        assert.ok(!args.includes('--squash'));
+        cb(null, '', '');
+        return;
+      }
+      cb(new Error(`unexpected exec: ${cmd} ${args.join(' ')}`));
+    };
+
+    const r = await tryGhPrQueueAutoMerge('/tmp/r', 'https://github.com/o/r/pull/47');
+    assert.equal(r.ok, true);
+    assert.equal(r.mergeMethod, 'merge');
+    assert.equal(calls.length, 2);
+    assert.match(calls[0].args[1], /^repos\/o\/r$/);
+    assert.equal(calls[1].args[0], 'pr');
+  });
+
+  it('fails fast when allow_auto_merge is false (repo setting)', async () => {
+    cursorPostRunExec.execFile = (_cmd, args, _opts, cb) => {
+      if (args[0] === 'api') {
+        cb(
+          null,
+          JSON.stringify({
+            allow_squash_merge: true,
+            allow_merge_commit: true,
+            allow_rebase_merge: true,
+            allow_auto_merge: false,
+          }),
+          ''
+        );
+        return;
+      }
+      cb(new Error('gh pr merge must not run when auto-merge is disabled at repo level'));
+    };
+    const r = await tryGhPrQueueAutoMerge('/tmp/r', 'https://github.com/o/rr/pull/2');
+    assert.equal(r.ok, false);
+    assert.match(r.error, /Allow auto-merge/);
   });
 });

--- a/test/cursorPostRunPrMergeHelpers.test.js
+++ b/test/cursorPostRunPrMergeHelpers.test.js
@@ -3,6 +3,8 @@ import { describe, it } from 'node:test';
 import {
   githubPrMergeErrorLooksStaleHead,
   githubPrUpdateBranchErrorLooksNoOp,
+  pickGithubMergeStrategy,
+  githubMergeMethodSummaryLabel,
 } from '../whatsapp/agents/cursorPostRun.js';
 
 describe('PR merge / update-branch error heuristics', () => {
@@ -21,5 +23,39 @@ describe('PR merge / update-branch error heuristics', () => {
       '{"message":"There are no new commits on the base branch.","status":"422"}gh: There are no new commits on the base branch. (HTTP 422)';
     assert.equal(githubPrUpdateBranchErrorLooksNoOp(msg), true);
     assert.equal(githubPrUpdateBranchErrorLooksNoOp('merge conflict on update-branch'), false);
+  });
+
+  it('pickGithubMergeStrategy prefers squash, then merge, then rebase', () => {
+    assert.equal(
+      pickGithubMergeStrategy({
+        allow_squash_merge: true,
+        allow_merge_commit: true,
+        allow_rebase_merge: true,
+      }),
+      'squash'
+    );
+    assert.equal(
+      pickGithubMergeStrategy({
+        allow_squash_merge: false,
+        allow_merge_commit: true,
+        allow_rebase_merge: true,
+      }),
+      'merge'
+    );
+    assert.equal(
+      pickGithubMergeStrategy({
+        allow_squash_merge: false,
+        allow_merge_commit: false,
+        allow_rebase_merge: true,
+      }),
+      'rebase'
+    );
+    assert.equal(pickGithubMergeStrategy({}), null);
+  });
+
+  it('githubMergeMethodSummaryLabel matches WhatsApp / note wording', () => {
+    assert.equal(githubMergeMethodSummaryLabel('squash'), 'squash');
+    assert.equal(githubMergeMethodSummaryLabel('merge'), 'merge commit');
+    assert.equal(githubMergeMethodSummaryLabel('rebase'), 'rebase');
   });
 });

--- a/whatsapp/agents/cursorPostRun.js
+++ b/whatsapp/agents/cursorPostRun.js
@@ -100,7 +100,7 @@ function postReviewAutofixEnabled() {
   return true;
 }
 
-/** After review + optional autofix, queue `gh pr merge --auto --squash` when guardrails pass (issue #13). Set `CURSOR_POST_RUN_PR_AUTO_MERGE=0` to disable. */
+/** After review + optional autofix, queue `gh pr merge --auto` with a merge method allowed on the repo (squash preferred; issue #47) when guardrails pass (issue #13). Set `CURSOR_POST_RUN_PR_AUTO_MERGE=0` to disable. */
 function prAutoMergeAfterReviewEnabled() {
   if (process.env.CURSOR_POST_RUN_PR_AUTO_MERGE === '0') return false;
   return true;
@@ -425,6 +425,30 @@ export function githubPrUpdateBranchErrorLooksNoOp(combinedMessage) {
 }
 
 /**
+ * Choose a merge strategy for `gh pr merge` from repository merge settings (REST: Repository).
+ * Prefers squash (previous bot default), then merge commit, then rebase.
+ * @param {{ allow_squash_merge?: boolean, allow_merge_commit?: boolean, allow_rebase_merge?: boolean }} caps
+ * @returns {'squash' | 'merge' | 'rebase' | null}
+ */
+export function pickGithubMergeStrategy(caps) {
+  const c = caps || {};
+  if (c.allow_squash_merge) return 'squash';
+  if (c.allow_merge_commit) return 'merge';
+  if (c.allow_rebase_merge) return 'rebase';
+  return null;
+}
+
+/**
+ * @param {'squash' | 'merge' | 'rebase'} strategy
+ * @returns {string}
+ */
+export function githubMergeMethodSummaryLabel(strategy) {
+  if (strategy === 'merge') return 'merge commit';
+  if (strategy === 'squash' || strategy === 'rebase') return strategy;
+  return 'merge';
+}
+
+/**
  * @param {string} prUrl
  * @returns {{ owner: string, repo: string, number: number } | null}
  */
@@ -504,32 +528,111 @@ async function tryGhPrReviewComment(repo, prUrl, body) {
 }
 
 /**
- * Enable GitHub auto-merge with squash for the PR (`gh pr merge --auto --squash`).
+ * Read merge / auto-merge flags for the PR’s base repo (REST GET /repos/{owner}/{repo}).
+ * @param {string} repo — git cwd for `gh`
+ * @param {string} owner
+ * @param {string} repoSlug
+ * @returns {Promise<{ ok: true, allow_squash_merge: boolean, allow_merge_commit: boolean, allow_rebase_merge: boolean, allow_auto_merge: boolean | null } | { ok: false, error: string }>}
+ */
+async function tryGhRepoMergeCapabilities(repo, owner, repoSlug) {
+  const execOpts = {
+    cwd: repo,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  };
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      [
+        'api',
+        `repos/${owner}/${repoSlug}`,
+        '--jq',
+        '{allow_squash_merge,allow_merge_commit,allow_rebase_merge,allow_auto_merge}',
+      ],
+      execOpts
+    );
+    const j = JSON.parse(stdout || '{}');
+    const auto = j.allow_auto_merge;
+    return {
+      ok: true,
+      allow_squash_merge: Boolean(j.allow_squash_merge),
+      allow_merge_commit: Boolean(j.allow_merge_commit),
+      allow_rebase_merge: Boolean(j.allow_rebase_merge),
+      allow_auto_merge: typeof auto === 'boolean' ? auto : null,
+    };
+  } catch (e) {
+    return { ok: false, error: e.stderr || e.message || String(e) };
+  }
+}
+
+function mergeStrategyToGhFlags(strategy) {
+  if (strategy === 'squash') return ['--squash'];
+  if (strategy === 'merge') return ['--merge'];
+  if (strategy === 'rebase') return ['--rebase'];
+  return ['--squash'];
+}
+
+/**
+ * Enable GitHub auto-merge for the PR using a merge method allowed by the repository (`gh pr merge --auto …`).
+ * Chooses squash, merge commit, or rebase from repo settings (issue #47 — do not assume squash is enabled).
  * If GitHub reports the head branch is out of date, merges base into head via the REST update-branch endpoint (once), then retries.
  * @param {string} repo
  * @param {string} prUrl
- * @returns {Promise<{ ok: boolean, error?: string, staleHeadSynced?: boolean }>}
+ * @returns {Promise<{ ok: boolean, error?: string, staleHeadSynced?: boolean, mergeMethod?: 'squash'|'merge'|'rebase' }>}
  */
 async function tryGhPrMergeAutoSquash(repo, prUrl) {
   const url = String(prUrl || '').trim();
   if (!/^https:\/\/github\.com\/.+\/pull\/\d+/i.test(url)) {
     return { ok: false, error: 'Invalid PR URL for gh pr merge' };
   }
+  const parsed = ownerRepoPullNumberFromGithubPullUrl(url);
+  if (!parsed) {
+    return { ok: false, error: 'Invalid PR URL for gh pr merge' };
+  }
+
+  const caps = await tryGhRepoMergeCapabilities(repo, parsed.owner, parsed.repo);
+  if (!caps.ok) {
+    return {
+      ok: false,
+      error:
+        `Could not read repository merge settings (GitHub API): ${caps.error}. Fix \`gh auth\` or network, then retry.`,
+    };
+  }
+  if (caps.allow_auto_merge === false) {
+    return {
+      ok: false,
+      error:
+        'GitHub **Allow auto-merge** is disabled for this repository. Enable it under **Settings → General → Pull requests** (separate from choosing squash vs merge commit). Then `gh pr merge --auto` can queue the merge.',
+    };
+  }
+
+  const strategy = pickGithubMergeStrategy(caps);
+  if (!strategy) {
+    return {
+      ok: false,
+      error:
+        'No merge method is allowed on this repository (squash, merge commit, and rebase are all disabled). Enable at least one under **Settings → General → Pull requests**.',
+    };
+  }
+
   const execOpts = {
     cwd: repo,
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
   };
-  async function mergeAutoSquash() {
-    await execFileAsync('gh', ['pr', 'merge', url, '--auto', '--squash'], execOpts);
+
+  async function mergeAuto() {
+    const flags = mergeStrategyToGhFlags(strategy);
+    await execFileAsync('gh', ['pr', 'merge', url, '--auto', ...flags], execOpts);
   }
+
   try {
-    await mergeAutoSquash();
-    return { ok: true };
+    await mergeAuto();
+    return { ok: true, mergeMethod: strategy };
   } catch (e) {
     const errFirst = e.stderr || e.message || String(e);
     if (!prStaleHeadSyncBeforeAutoMergeEnabled() || !githubPrMergeErrorLooksStaleHead(errFirst)) {
-      return { ok: false, error: errFirst };
+      return { ok: false, error: errFirst, mergeMethod: strategy };
     }
     if (postRunLogEnabled()) {
       console.log('[cursorPostRun]', 'auto-merge blocked (stale head); GitHub API update-branch then retry', url);
@@ -539,16 +642,18 @@ async function tryGhPrMergeAutoSquash(repo, prUrl) {
       return {
         ok: false,
         error: `${errFirst.trim()}\n\nGitHub update-branch failed: ${sync.error || 'unknown'}`,
+        mergeMethod: strategy,
       };
     }
     try {
-      await mergeAutoSquash();
-      return { ok: true, staleHeadSynced: !sync.noOp };
+      await mergeAuto();
+      return { ok: true, staleHeadSynced: !sync.noOp, mergeMethod: strategy };
     } catch (e2) {
       const errSecond = e2.stderr || e2.message || String(e2);
       return {
         ok: false,
         error: `${errFirst.trim()}\n\nAfter update-branch: ${errSecond.trim()}`,
+        mergeMethod: strategy,
       };
     }
   }
@@ -1393,7 +1498,7 @@ async function runPostCloseChangesDeepInfra({ issueBlock }) {
  * on the same branch (no new PR), then commit and push when there are changes. On autofix failure, the WhatsApp note
  * and an extra PR comment warn not to merge. Disable with `CURSOR_POST_RUN_AUTOFIX=0`.
  * When guardrails pass (`VERDICT: APPROVE`, or `REQUEST_CHANGES` with a successful autofix push), runs
- * `gh pr merge --auto --squash` and polls the linked issue until `CLOSED` or a bounded timeout (issue #13).
+ * `gh pr merge --auto` using a merge method allowed on the repo (squash preferred; issue #47) and polls the linked issue until `CLOSED` or a bounded timeout (issue #13).
  * If GitHub reports the PR head is out of date, syncs it via `gh api PUT …/update-branch` once (Debian `gh` often lacks `pr update-branch`), then retries auto-merge; disable with `CURSOR_POST_RUN_PR_STALE_HEAD_SYNC=0`.
  * When the issue is confirmed **CLOSED**, sends a separate **“changes made”** email (DeepInfra
  * `meta-llama/Meta-Llama-3-8B-Instruct` by default) to `CURSOR_REVIEW_EMAIL_TO` via Gmail SMTP (issue #14).
@@ -1721,19 +1826,23 @@ export async function maybeCommitReviewEmail(opts) {
 
   if (prAutoMergeAfterReviewEnabled() && prAfterPushEnabled() && prResult?.ok) {
     if (prAutoMergeResult) {
+      const mergeBracket =
+        prAutoMergeResult.mergeMethod != null
+          ? ` (${githubMergeMethodSummaryLabel(prAutoMergeResult.mergeMethod)})`
+          : '';
       if (prAutoMergeResult.ok) {
         if (issueCloseWait?.closed) {
           parts.push(
-            `GitHub **auto-merge (squash)** was enabled for the PR; linked issue **#${issueNum}** is **closed**.`
+            `GitHub **auto-merge${mergeBracket}** was enabled for the PR; linked issue **#${issueNum}** is **closed**.`
           );
         } else if (issueCloseWait?.timedOut) {
           parts.push(
-            `**Merge pending / issue not yet closed:** auto-merge (squash) was requested for the PR, but issue **#${issueNum}** is still **not closed** after waiting (bounded poll). The merge may still complete in the background once checks and branch rules allow. **Post-close summary email** was not sent for the same reason (issue never reached CLOSED within \`CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS\`). There is no follow-up send after this run ends; raise the wait time or send the summary manually if CI is slow.`
+            `**Merge pending / issue not yet closed:** auto-merge${mergeBracket} was requested for the PR, but issue **#${issueNum}** is still **not closed** after waiting (bounded poll). The merge may still complete in the background once checks and branch rules allow. **Post-close summary email** was not sent for the same reason (issue never reached CLOSED within \`CURSOR_POST_RUN_ISSUE_CLOSE_MAX_WAIT_MS\`). There is no follow-up send after this run ends; raise the wait time or send the summary manually if CI is slow.`
           );
         }
       } else {
         parts.push(
-          `GitHub auto-merge (squash) was **not** enabled: ${prAutoMergeResult.error || 'unknown error'}.`
+          `GitHub auto-merge${mergeBracket} was **not** enabled: ${prAutoMergeResult.error || 'unknown error'}.`
         );
       }
     } else if (reviewOutcome === 'success' && !autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix })) {

--- a/whatsapp/agents/cursorPostRun.js
+++ b/whatsapp/agents/cursorPostRun.js
@@ -1,9 +1,8 @@
 import dotenv from 'dotenv';
-import { execFile } from 'child_process';
+import * as childProcess from 'child_process';
 import { writeFile, unlink } from 'fs/promises';
 import { basename, join } from 'path';
 import { tmpdir } from 'os';
-import { promisify } from 'util';
 import OpenAI from 'openai';
 import nodemailer from 'nodemailer';
 import { logAgentInvocation, addCompletionUsage } from './agentUsageLog.js';
@@ -22,7 +21,32 @@ import { runPostReviewAutofixMergeFlow } from './cursorPostRunReviewFollowUp.js'
 
 dotenv.config();
 
-const execFileAsync = promisify(execFile);
+/**
+ * Indirection for `execFile` so unit tests can replace `execFile` without mocking `child_process` (non-configurable in Node).
+ * @type {{ execFile: typeof childProcess.execFile }}
+ */
+export const cursorPostRunExec = {
+  execFile: (command, args, options, callback) =>
+    childProcess.execFile(command, args, options, callback),
+};
+
+/**
+ * Same contract as `promisify(child_process.execFile)`: resolves to `{ stdout, stderr }`.
+ * Do not `promisify` a wrapper around `execFile` — that drops the custom promisify implementation and breaks callers that destructure `{ stdout }`.
+ */
+function execFileAsync(command, args, options) {
+  return new Promise((resolve, reject) => {
+    cursorPostRunExec.execFile(command, args, options, (err, stdout, stderr) => {
+      if (err) {
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -532,9 +556,9 @@ async function tryGhPrReviewComment(repo, prUrl, body) {
  * @param {string} repo — git cwd for `gh`
  * @param {string} owner
  * @param {string} repoSlug
- * @returns {Promise<{ ok: true, allow_squash_merge: boolean, allow_merge_commit: boolean, allow_rebase_merge: boolean, allow_auto_merge: boolean | null } | { ok: false, error: string }>}
+ * @returns {Promise<{ ok: true, allow_squash_merge: boolean, allow_merge_commit: boolean, allow_rebase_merge: boolean, allow_auto_merge: boolean } | { ok: false, error: string }>}
  */
-async function tryGhRepoMergeCapabilities(repo, owner, repoSlug) {
+export async function tryGhRepoMergeCapabilities(repo, owner, repoSlug) {
   const execOpts = {
     cwd: repo,
     encoding: 'utf8',
@@ -551,14 +575,46 @@ async function tryGhRepoMergeCapabilities(repo, owner, repoSlug) {
       ],
       execOpts
     );
-    const j = JSON.parse(stdout || '{}');
-    const auto = j.allow_auto_merge;
+    const raw = String(stdout ?? '').trim();
+    let j;
+    try {
+      j = JSON.parse(raw);
+    } catch (parseErr) {
+      const bit = raw.length > 240 ? `${raw.slice(0, 240)}…` : raw || '(empty stdout)';
+      return {
+        ok: false,
+        error: `Could not parse gh api --jq JSON for merge settings: ${parseErr.message || String(parseErr)}. Output: ${bit}`,
+      };
+    }
+    if (!j || typeof j !== 'object' || Array.isArray(j)) {
+      return { ok: false, error: 'gh api --jq returned a non-object for merge settings.' };
+    }
+    const required = [
+      'allow_squash_merge',
+      'allow_merge_commit',
+      'allow_rebase_merge',
+      'allow_auto_merge',
+    ];
+    for (const k of required) {
+      if (!Object.prototype.hasOwnProperty.call(j, k)) {
+        return {
+          ok: false,
+          error: `GitHub repo API jq output missing "${k}"; cannot read merge settings reliably.`,
+        };
+      }
+    }
+    if (typeof j.allow_auto_merge !== 'boolean') {
+      return {
+        ok: false,
+        error: `GitHub repo API returned non-boolean allow_auto_merge (${JSON.stringify(j.allow_auto_merge)}). Refusing to guess; check gh/API version and repo access.`,
+      };
+    }
     return {
       ok: true,
       allow_squash_merge: Boolean(j.allow_squash_merge),
       allow_merge_commit: Boolean(j.allow_merge_commit),
       allow_rebase_merge: Boolean(j.allow_rebase_merge),
-      allow_auto_merge: typeof auto === 'boolean' ? auto : null,
+      allow_auto_merge: j.allow_auto_merge,
     };
   } catch (e) {
     return { ok: false, error: e.stderr || e.message || String(e) };
@@ -573,14 +629,14 @@ function mergeStrategyToGhFlags(strategy) {
 }
 
 /**
- * Enable GitHub auto-merge for the PR using a merge method allowed by the repository (`gh pr merge --auto …`).
- * Chooses squash, merge commit, or rebase from repo settings (issue #47 — do not assume squash is enabled).
+ * Queue auto-merge for the PR via `gh pr merge --auto`, using a merge method the repo allows (squash, merge commit, or rebase).
+ * Issue #47: never assume squash is enabled; read repo flags first.
  * If GitHub reports the head branch is out of date, merges base into head via the REST update-branch endpoint (once), then retries.
  * @param {string} repo
  * @param {string} prUrl
  * @returns {Promise<{ ok: boolean, error?: string, staleHeadSynced?: boolean, mergeMethod?: 'squash'|'merge'|'rebase' }>}
  */
-async function tryGhPrMergeAutoSquash(repo, prUrl) {
+export async function tryGhPrQueueAutoMerge(repo, prUrl) {
   const url = String(prUrl || '').trim();
   if (!/^https:\/\/github\.com\/.+\/pull\/\d+/i.test(url)) {
     return { ok: false, error: 'Invalid PR URL for gh pr merge' };
@@ -598,6 +654,7 @@ async function tryGhPrMergeAutoSquash(repo, prUrl) {
         `Could not read repository merge settings (GitHub API): ${caps.error}. Fix \`gh auth\` or network, then retry.`,
     };
   }
+  /* `gh pr merge --auto` only queues auto-merge when the repo allows it; otherwise GitHub rejects. Fail fast with setup guidance (issue #47 review). */
   if (caps.allow_auto_merge === false) {
     return {
       ok: false,
@@ -635,7 +692,11 @@ async function tryGhPrMergeAutoSquash(repo, prUrl) {
       return { ok: false, error: errFirst, mergeMethod: strategy };
     }
     if (postRunLogEnabled()) {
-      console.log('[cursorPostRun]', 'auto-merge blocked (stale head); GitHub API update-branch then retry', url);
+      console.log(
+        '[cursorPostRun]',
+        'tryGhPrQueueAutoMerge: stale head blocked auto-merge; GitHub API update-branch then retry',
+        url
+      );
     }
     const sync = await tryGhPrUpdateBranchViaApi(repo, url);
     if (!sync.ok) {
@@ -1697,7 +1758,7 @@ export async function maybeCommitReviewEmail(opts) {
     pushResultOk: Boolean(pushResult?.ok),
     runSinglePostReviewAutofix,
     tryGhPrReviewComment,
-    tryGhPrMergeAutoSquash,
+    tryGhPrQueueAutoMerge,
     waitForGithubIssueClosed,
     logPost,
   });

--- a/whatsapp/agents/cursorPostRunReviewFollowUp.js
+++ b/whatsapp/agents/cursorPostRunReviewFollowUp.js
@@ -5,7 +5,7 @@ import {
 
 /**
  * Post-LLM-review steps: optional single autofix pass, merge-gate PR comment, auto-merge + issue poll.
- * Dependencies are injected so `node:test` can mock `gh`, git-backed helpers, and Cursor CLI.
+ * Inject `tryGhPrQueueAutoMerge` (from cursorPostRun) so `node:test` can mock `gh` and related helpers.
  */
 export async function runPostReviewAutofixMergeFlow({
   repo,
@@ -22,7 +22,7 @@ export async function runPostReviewAutofixMergeFlow({
   pushResultOk,
   runSinglePostReviewAutofix,
   tryGhPrReviewComment,
-  tryGhPrMergeAutoSquash,
+  tryGhPrQueueAutoMerge,
   waitForGithubIssueClosed,
   logPost = () => {},
 }) {
@@ -69,8 +69,8 @@ export async function runPostReviewAutofixMergeFlow({
     prResult?.ok &&
     autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix })
   ) {
-    prAutoMergeResult = await tryGhPrMergeAutoSquash(repo, prResult.url);
-    logPost('gh pr merge --auto (repo merge method)', prAutoMergeResult);
+    prAutoMergeResult = await tryGhPrQueueAutoMerge(repo, prResult.url);
+    logPost('tryGhPrQueueAutoMerge', prAutoMergeResult);
     if (prAutoMergeResult.ok) {
       issueCloseWait = await waitForGithubIssueClosed(repo, issueNum);
       logPost('wait for issue closed', issueCloseWait);

--- a/whatsapp/agents/cursorPostRunReviewFollowUp.js
+++ b/whatsapp/agents/cursorPostRunReviewFollowUp.js
@@ -70,7 +70,7 @@ export async function runPostReviewAutofixMergeFlow({
     autoMergeAllowedByReviewGate({ reviewOutcome, reviewVerdict, postReviewAutofix })
   ) {
     prAutoMergeResult = await tryGhPrMergeAutoSquash(repo, prResult.url);
-    logPost('gh pr merge --auto --squash', prAutoMergeResult);
+    logPost('gh pr merge --auto (repo merge method)', prAutoMergeResult);
     if (prAutoMergeResult.ok) {
       issueCloseWait = await waitForGithubIssueClosed(repo, issueNum);
       logPost('wait for issue closed', issueCloseWait);


### PR DESCRIPTION
Fixes #47

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-47-bug-pr-not-being-merged`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #47

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/47
**State:** OPEN
**Title:** Bug: PR not being merged

## Body
Investigate why PRs are not being merged. It might be due to the LLM review branch step.
Logs: Github auto-merge squash not enabled.
This option has been enabled already in github repo settings.