### PR TITLE
feat: feat: add DeepInfra images/edits helper (Qwen-Image-Edit) (#53)

### DIFF
--- a/models/models.js
+++ b/models/models.js
@@ -500,6 +500,27 @@ export const DEEPINFRA_IMAGE_EDITS_URL = 'https://api.deepinfra.com/v1/openai/im
 export const DEEPINFRA_QWEN_IMAGE_EDIT_MODEL = 'Qwen/Qwen-Image-Edit';
 
 /**
+ * Decode the first OpenAI-style image object (`b64_json` or download `url`).
+ * Used by DeepInfra image helpers so decode/download behavior stays consistent.
+ *
+ * @param {{ b64_json?: string; url?: string } | null | undefined} entry
+ * @param {{ fetchFn?: typeof fetch; downloadFailureMessage?: string }} [options]
+ * @returns {Promise<Buffer>}
+ */
+export async function bufferFromOpenAIImageDataEntry(entry, options = {}) {
+  const { fetchFn = fetch, downloadFailureMessage = 'Failed to download image' } = options;
+  if (entry?.b64_json) {
+    return Buffer.from(entry.b64_json, 'base64');
+  }
+  if (entry?.url) {
+    const r = await fetchFn(entry.url);
+    if (!r.ok) throw new Error(`${downloadFailureMessage} (HTTP ${r.status})`);
+    return Buffer.from(await r.arrayBuffer());
+  }
+  throw new Error('DeepInfra returned no image data (expected b64_json or url).');
+}
+
+/**
  * Scalar fields for DeepInfra `POST /v1/openai/images/edits` multipart body (the `image` file is appended separately).
  * @param {{ model?: string; size?: string; n?: number; prompt?: string }} [args]
  */
@@ -588,6 +609,10 @@ export async function deepInfraImagesEdit(args, options = {}) {
   if (image == null) {
     throw new Error('Image buffer is required for DeepInfra image edits.');
   }
+  // Blob in Node accepts Buffer and Uint8Array (Buffer subclasses Uint8Array).
+  if (!Buffer.isBuffer(image) && !(image instanceof Uint8Array)) {
+    throw new Error('Image must be a Buffer or Uint8Array for DeepInfra image edits.');
+  }
 
   const fields = buildDeepInfraImageEditsFormFields({ model, size, n, prompt });
   const form = new FormData();
@@ -637,16 +662,10 @@ export async function sdxlTurboGenerateResponse(prompt, options = {}) {
   );
 
   const entry = json?.data?.[0];
-  let buffer;
-  if (entry?.b64_json) {
-    buffer = Buffer.from(entry.b64_json, 'base64');
-  } else if (entry?.url) {
-    const r = await (fetchFn || fetch)(entry.url);
-    if (!r.ok) throw new Error(`Failed to download generated image (HTTP ${r.status})`);
-    buffer = Buffer.from(await r.arrayBuffer());
-  } else {
-    throw new Error('DeepInfra returned no image data (expected b64_json or url).');
-  }
+  const buffer = await bufferFromOpenAIImageDataEntry(entry, {
+    fetchFn: fetchFn || fetch,
+    downloadFailureMessage: 'Failed to download generated image',
+  });
 
   // Save to assets/generated using the existing naming scheme.
   const filepath = await saveGeneratedImage(
@@ -671,30 +690,27 @@ export async function sdxlTurboGenerateResponse(prompt, options = {}) {
  * }} args
  * @param {{ fetchFn?: typeof fetch }} [options]
  * @returns {Promise<{ buffer: Buffer; filepath: string|null }>}
+ * Persisted beside other bot images via {@link saveGeneratedImage}: each run gets a distinct
+ * `{ISO timestamp}_{sanitizedSlug}.png` under `assets/generated/` (prompt-based slug or `qwen_edit` fallback).
  */
 export async function qwenImageEditGenerateResponse(args, options = {}) {
+  const resolvedArgs = args ?? {};
   const { fetchFn } = options;
   const json = await deepInfraImagesEdit(
     {
-      ...args,
-      model: args.model ?? DEEPINFRA_QWEN_IMAGE_EDIT_MODEL,
+      ...resolvedArgs,
+      model: resolvedArgs.model ?? DEEPINFRA_QWEN_IMAGE_EDIT_MODEL,
     },
     { fetchFn },
   );
 
   const entry = json?.data?.[0];
-  let buffer;
-  if (entry?.b64_json) {
-    buffer = Buffer.from(entry.b64_json, 'base64');
-  } else if (entry?.url) {
-    const r = await (fetchFn || fetch)(entry.url);
-    if (!r.ok) throw new Error(`Failed to download edited image (HTTP ${r.status})`);
-    buffer = Buffer.from(await r.arrayBuffer());
-  } else {
-    throw new Error('DeepInfra returned no image data (expected b64_json or url).');
-  }
+  const buffer = await bufferFromOpenAIImageDataEntry(entry, {
+    fetchFn: fetchFn || fetch,
+    downloadFailureMessage: 'Failed to download edited image',
+  });
 
-  const slugBase = args.prompt?.trim() ? args.prompt : 'qwen_edit';
+  const slugBase = resolvedArgs.prompt?.trim() ? resolvedArgs.prompt : 'qwen_edit';
   const filepath = await saveGeneratedImage(
     { data: [{ b64_json: buffer.toString('base64') }] },
     `qwen_edit_${slugBase}`,

--- a/models/models.js
+++ b/models/models.js
@@ -494,6 +494,29 @@ export function buildDeepInfraImageGenerationsBody(args) {
   };
 }
 
+export const DEEPINFRA_IMAGE_EDITS_URL = 'https://api.deepinfra.com/v1/openai/images/edits';
+
+/** Default model for OpenAI-compatible image edits on DeepInfra (Qwen Image Edit). */
+export const DEEPINFRA_QWEN_IMAGE_EDIT_MODEL = 'Qwen/Qwen-Image-Edit';
+
+/**
+ * Scalar fields for DeepInfra `POST /v1/openai/images/edits` multipart body (the `image` file is appended separately).
+ * @param {{ model?: string; size?: string; n?: number; prompt?: string }} [args]
+ */
+export function buildDeepInfraImageEditsFormFields(args = {}) {
+  const {
+    model = DEEPINFRA_QWEN_IMAGE_EDIT_MODEL,
+    size = '1024x1024',
+    n = 1,
+    prompt,
+  } = args;
+  const out = { model, size, n };
+  if (prompt != null && String(prompt).trim() !== '') {
+    out.prompt = String(prompt).trim();
+  }
+  return out;
+}
+
 /**
  * Call DeepInfra OpenAI-compatible image generations endpoint.
  * Returns the raw JSON response.
@@ -534,6 +557,73 @@ export async function deepInfraImagesGenerate(args, options = {}) {
 }
 
 /**
+ * Call DeepInfra OpenAI-compatible image edits endpoint (multipart form-data).
+ *
+ * @param {{
+ *   image: Buffer | Uint8Array;
+ *   imageFilename?: string;
+ *   imageMimeType?: string;
+ *   prompt?: string;
+ *   model?: string;
+ *   size?: string;
+ *   n?: number;
+ * }} args
+ * @param {{ signal?: AbortSignal; fetchFn?: typeof fetch }} [options]
+ */
+export async function deepInfraImagesEdit(args, options = {}) {
+  if (!process.env.DEEPINFRA_API_KEY?.trim()) {
+    throw new Error('DEEPINFRA_API_KEY is not set; cannot call DeepInfra image edits.');
+  }
+  const { signal, fetchFn = fetch } = options;
+  const {
+    image,
+    imageFilename = 'image.png',
+    imageMimeType = 'image/png',
+    prompt,
+    model,
+    size,
+    n,
+  } = args || {};
+
+  if (image == null) {
+    throw new Error('Image buffer is required for DeepInfra image edits.');
+  }
+
+  const fields = buildDeepInfraImageEditsFormFields({ model, size, n, prompt });
+  const form = new FormData();
+  const blob = new Blob([image], { type: imageMimeType });
+  form.append('image', blob, imageFilename);
+  for (const [key, value] of Object.entries(fields)) {
+    form.append(key, typeof value === 'number' ? String(value) : value);
+  }
+
+  const res = await fetchFn(DEEPINFRA_IMAGE_EDITS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.DEEPINFRA_API_KEY}`,
+    },
+    body: form,
+    ...(signal ? { signal } : {}),
+  });
+
+  let json;
+  try {
+    json = await res.json();
+  } catch (e) {
+    throw new Error(`DeepInfra image edits API returned non-JSON (HTTP ${res.status})`);
+  }
+
+  if (!res.ok) {
+    const msg =
+      json && (json.error?.message || json.message)
+        ? String(json.error?.message || json.message)
+        : 'Unknown error';
+    throw new Error(`DeepInfra image edits API error (HTTP ${res.status}): ${msg}`);
+  }
+  return json;
+}
+
+/**
  * Generate an image with Stability SDXL Turbo via DeepInfra (OpenAI-compatible images API).
  * @param {string} prompt
  * @param {{ size?: string; fetchFn?: typeof fetch }} [options]
@@ -566,6 +656,53 @@ export async function sdxlTurboGenerateResponse(prompt, options = {}) {
 
   return { buffer, filepath };
 }
+
+/**
+ * Edit an image with Qwen Image Edit via DeepInfra (`/v1/openai/images/edits`).
+ *
+ * @param {{
+ *   image: Buffer | Uint8Array;
+ *   prompt?: string;
+ *   imageFilename?: string;
+ *   imageMimeType?: string;
+ *   model?: string;
+ *   size?: string;
+ *   n?: number;
+ * }} args
+ * @param {{ fetchFn?: typeof fetch }} [options]
+ * @returns {Promise<{ buffer: Buffer; filepath: string|null }>}
+ */
+export async function qwenImageEditGenerateResponse(args, options = {}) {
+  const { fetchFn } = options;
+  const json = await deepInfraImagesEdit(
+    {
+      ...args,
+      model: args.model ?? DEEPINFRA_QWEN_IMAGE_EDIT_MODEL,
+    },
+    { fetchFn },
+  );
+
+  const entry = json?.data?.[0];
+  let buffer;
+  if (entry?.b64_json) {
+    buffer = Buffer.from(entry.b64_json, 'base64');
+  } else if (entry?.url) {
+    const r = await (fetchFn || fetch)(entry.url);
+    if (!r.ok) throw new Error(`Failed to download edited image (HTTP ${r.status})`);
+    buffer = Buffer.from(await r.arrayBuffer());
+  } else {
+    throw new Error('DeepInfra returned no image data (expected b64_json or url).');
+  }
+
+  const slugBase = args.prompt?.trim() ? args.prompt : 'qwen_edit';
+  const filepath = await saveGeneratedImage(
+    { data: [{ b64_json: buffer.toString('base64') }] },
+    `qwen_edit_${slugBase}`,
+  );
+
+  return { buffer, filepath };
+}
+
 export async function recipeGenerateResponse(userMessage) {
   try {
     const completion = await openai.completions.create({

--- a/test/deepInfraImageEditsParams.test.js
+++ b/test/deepInfraImageEditsParams.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildDeepInfraImageEditsFormFields,
+  DEEPINFRA_QWEN_IMAGE_EDIT_MODEL,
+} from '../models/models.js';
+
+describe('buildDeepInfraImageEditsFormFields', () => {
+  it('fills defaults and omits prompt when not provided', () => {
+    const fields = buildDeepInfraImageEditsFormFields({});
+    assert.equal(fields.model, DEEPINFRA_QWEN_IMAGE_EDIT_MODEL);
+    assert.equal(fields.size, '1024x1024');
+    assert.equal(fields.n, 1);
+    assert.equal('prompt' in fields, false);
+  });
+
+  it('omits prompt for blank or whitespace-only strings', () => {
+    assert.equal('prompt' in buildDeepInfraImageEditsFormFields({ prompt: '' }), false);
+    assert.equal('prompt' in buildDeepInfraImageEditsFormFields({ prompt: '  \n\t  ' }), false);
+  });
+
+  it('forwards explicit model, size, n, and trimmed prompt', () => {
+    const fields = buildDeepInfraImageEditsFormFields({
+      model: 'other/model',
+      size: '512x512',
+      n: 2,
+      prompt: '  make it warmer  ',
+    });
+    assert.deepEqual(fields, {
+      model: 'other/model',
+      size: '512x512',
+      n: 2,
+      prompt: 'make it warmer',
+    });
+  });
+});

--- a/test/deepInfraImagesEdit.test.js
+++ b/test/deepInfraImagesEdit.test.js
@@ -1,0 +1,162 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  bufferFromOpenAIImageDataEntry,
+  deepInfraImagesEdit,
+  DEEPINFRA_IMAGE_EDITS_URL,
+  DEEPINFRA_QWEN_IMAGE_EDIT_MODEL,
+} from '../models/models.js';
+
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+describe('deepInfraImagesEdit', () => {
+  let prevKey;
+
+  beforeEach(() => {
+    prevKey = process.env.DEEPINFRA_API_KEY;
+    process.env.DEEPINFRA_API_KEY = 'test-deepinfra-key';
+  });
+
+  afterEach(() => {
+    if (prevKey === undefined) delete process.env.DEEPINFRA_API_KEY;
+    else process.env.DEEPINFRA_API_KEY = prevKey;
+  });
+
+  it('throws when DEEPINFRA_API_KEY is missing', async () => {
+    delete process.env.DEEPINFRA_API_KEY;
+    await assert.rejects(
+      () =>
+        deepInfraImagesEdit(
+          { image: Buffer.from([0]) },
+          { fetchFn: async () => new Response('{}') },
+        ),
+      /DEEPINFRA_API_KEY is not set.*image edits/i,
+    );
+  });
+
+  it('rejects non-Buffer/non-Uint8Array image payloads before fetch', async () => {
+    let invoked = false;
+    const fetchFn = async () => {
+      invoked = true;
+      return new Response('{}');
+    };
+    await assert.rejects(
+      () => deepInfraImagesEdit({ image: 'not-binary' }, { fetchFn }),
+      /Image must be a Buffer or Uint8Array/i,
+    );
+    assert.equal(invoked, false);
+  });
+
+  it('POSTs multipart to the edits URL with Bearer auth and expected form fields', async () => {
+    const captures = [];
+
+    const fetchFn = async (url, init) => {
+      captures.push({ url, init });
+      return new Response(
+        JSON.stringify({ data: [{ b64_json: TINY_PNG_B64 }] }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    };
+
+    const image = Buffer.from([1, 2, 3, 4]);
+    await deepInfraImagesEdit(
+      {
+        image,
+        prompt: '  warm tint  ',
+        imageFilename: 'input.png',
+        imageMimeType: 'image/png',
+        size: '512x512',
+        n: 2,
+      },
+      { fetchFn },
+    );
+
+    assert.equal(captures.length, 1);
+    assert.equal(captures[0].url, DEEPINFRA_IMAGE_EDITS_URL);
+    assert.equal(captures[0].init.method ?? 'GET', 'POST');
+    assert.equal(captures[0].init.headers.Authorization, 'Bearer test-deepinfra-key');
+
+    assert.ok(captures[0].init.body instanceof FormData);
+    const form = captures[0].init.body;
+    const fields = [...form.entries()];
+
+    const get = (k) =>
+      fields
+        .filter(([name]) => name === k)
+        .map(([, v]) => v);
+
+    assert.equal(get('model').join(), DEEPINFRA_QWEN_IMAGE_EDIT_MODEL);
+    assert.equal(get('size').join(), '512x512');
+    assert.equal(get('n').join(), '2');
+    assert.equal(get('prompt').join(), 'warm tint');
+
+    const imageParts = get('image');
+    assert.equal(imageParts.length, 1);
+    const fileOrBlob = imageParts[0];
+    assert.ok(
+      fileOrBlob instanceof Blob || (typeof File !== 'undefined' && fileOrBlob instanceof File),
+    );
+
+    assert.ok(image.equals(Buffer.from(await fileOrBlob.arrayBuffer())));
+  });
+
+  it('parses HTTP 200 JSON with b64_json image entry', async () => {
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ data: [{ b64_json: TINY_PNG_B64 }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    const out = await deepInfraImagesEdit({ image: new Uint8Array([9, 9]) }, { fetchFn });
+    assert.equal(Buffer.from(out.data[0].b64_json, 'base64').length > 0, true);
+  });
+
+  it('parses HTTP 200 JSON with url-only image entry', async () => {
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ data: [{ url: 'https://example.invalid/out.png' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    const out = await deepInfraImagesEdit({ image: Buffer.from([0xff]) }, { fetchFn });
+    assert.equal(out.data[0].url, 'https://example.invalid/out.png');
+  });
+
+  it('works with Uint8Array image input for multipart Blob', async () => {
+    const fetchFn = async (_, init) =>
+      new Response(JSON.stringify({ data: [{ b64_json: TINY_PNG_B64 }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    const u8 = new Uint8Array([10, 20, 30]);
+    await deepInfraImagesEdit({ image: u8 }, { fetchFn });
+  });
+});
+
+describe('bufferFromOpenAIImageDataEntry', () => {
+  it('returns buffer from b64_json', async () => {
+    const buf = await bufferFromOpenAIImageDataEntry({ b64_json: TINY_PNG_B64 });
+    assert.equal(buf.equals(Buffer.from(TINY_PNG_B64, 'base64')), true);
+  });
+
+  it('downloads when only url is present', async () => {
+    const expected = Buffer.from([0xaa, 0xbb]);
+
+    const fetchFn = async (url) => {
+      assert.equal(url, 'https://cdn.example/out.bin');
+      return new Response(expected, { status: 200 });
+    };
+
+    const buf = await bufferFromOpenAIImageDataEntry(
+      { url: 'https://cdn.example/out.bin' },
+      { fetchFn },
+    );
+
+    assert.equal(buf.equals(expected), true);
+  });
+});


### PR DESCRIPTION
Fixes #53

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-53-feat-add-deepinfra-images-edits-helper-qwen-imag`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #53

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/53
**State:** OPEN
**Title:** feat: add DeepInfra images/edits helper (Qwen-Image-Edit)

## Body
## What to build
Add a small helper in the Node codebase that calls DeepInfra’s OpenAI-compatible image edit endpoint (`/v1/openai/images/edits`) using model `Qwen/Qwen-Image-Edit`.

This should accept an input image (from an on-disk file buffer) and return an output image buffer (b64 or downloaded URL), similar to how existing image generation helpers work.

## Acceptance criteria
- [ ] Add a function (or module) that can call `POST https://api.deepinfra.com/v1/openai/images/edits` with multipart form-data (`image`, `model=Qwen/Qwen-Image-Edit`, `n`, `size`, and optionally `prompt`/instruction if supported)
- [ ] Returns `{ buffer, filepath? }` or equivalent so WhatsApp commands can send the edited image
- [ ] Uses `DEEPINFRA_API_KEY` for auth and errors cleanly when missing
- [ ] Unit test(s) cover request body/options plumbing (pure builder function preferred)

## Blocked by
None - can start immediately