### PR TITLE
fix: feat: track last SDXL image per chat for iteration (#54)

### DIFF
--- a/test/helpCommand.test.js
+++ b/test/helpCommand.test.js
@@ -29,8 +29,8 @@ describe('help command text', () => {
     );
     assert.match(
       helpText,
-      /\*sdxl\* \[size\] \[prompt\]/,
-      'help should include the SDXL command',
+      /\*sdxl\+\*/,
+      'help should include the SDXL refine command',
     );
     assert.equal(
       SUMMARIZE_USAGE,

--- a/test/messageOrchestrator.test.js
+++ b/test/messageOrchestrator.test.js
@@ -81,6 +81,7 @@ function basePorts(overrides = {}) {
     },
     routes: {
       runSpritePlus: async () => ({ handled: false }),
+      runSdxlPlus: async () => ({ handled: false }),
       runCommandByFirstToken: async () => ({ handled: false }),
       runLegacyRoutes: async () => ({ handled: false }),
     },
@@ -105,6 +106,9 @@ describe('createMessageOrchestrator', () => {
           assert.match(m.text, /sprite\+/i);
           return { handled: true };
         },
+        async runSdxlPlus() {
+          return { handled: false };
+        },
         async runCommandByFirstToken() {
           log.push('cmd');
           return { handled: true };
@@ -120,6 +124,34 @@ describe('createMessageOrchestrator', () => {
     assert.deepEqual(log, ['sprite']);
   });
 
+  it('routes sdxl+ before command registry (sdxl+ wins)', async () => {
+    const log = [];
+    const ports = basePorts({
+      __log: log,
+      routes: {
+        async runSpritePlus() {
+          return { handled: false };
+        },
+        async runSdxlPlus(m) {
+          log.push('sdxl');
+          assert.match(m.text, /sdxl\+/i);
+          return { handled: true };
+        },
+        async runCommandByFirstToken() {
+          log.push('cmd');
+          return { handled: true };
+        },
+        async runLegacyRoutes() {
+          log.push('legacy');
+          return { handled: false };
+        },
+      },
+    });
+    const { handleInbound } = createMessageOrchestrator(ports);
+    await handleInbound(fakeInbound({ text: 'sdxl+ brighten' }));
+    assert.deepEqual(log, ['sdxl']);
+  });
+
   it('image branch is exclusive: command registry is not run for image messages', async () => {
     const log = [];
     const ports = basePorts({
@@ -127,6 +159,9 @@ describe('createMessageOrchestrator', () => {
       routes: {
         async runSpritePlus() {
           log.push('sprite');
+          return { handled: false };
+        },
+        async runSdxlPlus() {
           return { handled: false };
         },
         async runCommandByFirstToken() {
@@ -209,6 +244,9 @@ describe('createMessageOrchestrator', () => {
       __log: log,
       routes: {
         async runSpritePlus() {
+          return { handled: false };
+        },
+        async runSdxlPlus() {
           return { handled: false };
         },
         async runCommandByFirstToken() {

--- a/whatsapp/commands/help.js
+++ b/whatsapp/commands/help.js
@@ -11,6 +11,7 @@ export default async function helpCommand(sock, sender) {
 • *recipe* [prompt] — Generate a recipe
 • *image* [prompt] — Generate an image (DALL·E)
 • *sdxl* [size] [prompt] — Generate an image (SDXL Turbo via DeepInfra; sizes: 256x256, 512x512, 768x768, 1024x1024; default 1024x1024)
+• *sdxl+* [changes] — Refine the last SDXL image using the file saved on the server (no re-upload). Or *sdxl+* filename.png [changes] (assets/generated)
 • *sprite* [size] [description] — Pixel-art sprite (sizes: 16x16, 32x32, 48x48, 64x64, 128x128; default 32x32). Example: sprite 64x64 fire dragon
 • *sprite+* [changes] — Refine the last sprite using the file saved on the server (no re-upload). Or *sprite+* filename.png [changes] (assets/generated)
 

--- a/whatsapp/commands/sdxl.js
+++ b/whatsapp/commands/sdxl.js
@@ -1,7 +1,114 @@
-import { sdxlTurboGenerateResponse } from '../../models/models.js';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { sdxlTurboGenerateResponse, qwenImageEditGenerateResponse } from '../../models/models.js';
+import {
+  setLastSdxlPath,
+  getLastSdxlPath,
+  resolveSdxlGeneratedPngBasename,
+} from '../sdxlLastPath.js';
 
 const VALID_SIZES = ['256x256', '512x512', '768x768', '1024x1024'];
 const DEFAULT_SIZE = '1024x1024';
+
+const EXPLICIT_PNG = /^(\S+\.png)\s+([\s\S]+)$/i;
+
+function iterationHint(savedBasename) {
+  const ref = savedBasename ? `\`${savedBasename}\`` : 'the last SDXL image from this chat';
+  return (
+    `Refine (no re-upload): *sdxl+ what to change* uses ${ref}. ` +
+    `Or *sdxl+ yourfile.png what to change* (files in assets/generated on the server).`
+  );
+}
+
+export async function sdxlIterateCommand(sock, sender, text) {
+  const body = text.replace(/^\s*sdxl\+\s*/i, '').trim();
+  if (!body) {
+    await sock.sendMessage(sender, {
+      text: [
+        '*SDXL refine*',
+        '',
+        '*sdxl+* <what to change> — edits the last SDXL image from this chat (saved on server).',
+        '*sdxl+* <filename.png> <what to change> — pick a file from assets/generated.',
+      ].join('\n'),
+    });
+    return;
+  }
+
+  if (/^\S+\.png$/i.test(body)) {
+    await sock.sendMessage(sender, {
+      text: 'Add what to change after the filename, e.g. *sdxl+ file.png add sunset lighting*',
+    });
+    return;
+  }
+
+  let resolvedAbs;
+  let instruction;
+
+  const explicit = body.match(EXPLICIT_PNG);
+  if (explicit) {
+    try {
+      resolvedAbs = await resolveSdxlGeneratedPngBasename(explicit[1]);
+    } catch {
+      await sock.sendMessage(sender, {
+        text: `Could not open \`${explicit[1]}\`. Use the exact .png name from assets/generated.`,
+      });
+      return;
+    }
+    instruction = explicit[2].trim();
+  } else {
+    resolvedAbs = getLastSdxlPath(sender);
+    instruction = body;
+  }
+
+  if (!resolvedAbs) {
+    await sock.sendMessage(sender, {
+      text: 'No recent SDXL image for this chat. Run *sdxl …* first, or use *sdxl+ filename.png …*.',
+    });
+    return;
+  }
+
+  if (!instruction) {
+    await sock.sendMessage(sender, { text: 'Say what to change after the filename or after *sdxl+*.' });
+    return;
+  }
+
+  let buf;
+  try {
+    buf = await fs.readFile(resolvedAbs);
+  } catch {
+    await sock.sendMessage(sender, {
+      text: 'Could not read the saved image file. Generate again with *sdxl* or pick another *filename.png*.',
+    });
+    return;
+  }
+
+  if (buf.length > 4 * 1024 * 1024) {
+    await sock.sendMessage(sender, {
+      text: 'Image file too large for edit API (max 4MB).',
+    });
+    return;
+  }
+
+  await sock.sendMessage(sender, { text: 'Refining SDXL image…' });
+
+  try {
+    const { buffer, filepath } = await qwenImageEditGenerateResponse({
+      image: buf,
+      prompt: instruction,
+    });
+    if (filepath) setLastSdxlPath(sender, filepath);
+    const cap = instruction.length > 180 ? `${instruction.slice(0, 177)}…` : instruction;
+    await sock.sendMessage(sender, {
+      image: buffer,
+      caption: `SDXL refine: ${cap}`,
+    });
+    await sock.sendMessage(sender, { text: iterationHint(filepath ? path.basename(filepath) : null) });
+  } catch (e) {
+    await sock.sendMessage(sender, {
+      text: `SDXL refine failed: ${e?.message || String(e)}`,
+    });
+  }
+}
 
 function usageText() {
   return [
@@ -14,6 +121,8 @@ function usageText() {
     '',
     'Example:',
     '• sdxl 1024x1024 A photo of an astronaut riding a horse on Mars',
+    '',
+    'After an image is sent, use *sdxl+* to refine using the saved file on the server.',
   ].join('\n');
 }
 
@@ -44,16 +153,17 @@ export default async function sdxlCommand(sock, sender, text) {
   await sock.sendMessage(sender, { text: `Generating SDXL Turbo image (${size})...` });
 
   try {
-    const { buffer } = await sdxlTurboGenerateResponse(prompt, { size });
+    const { buffer, filepath } = await sdxlTurboGenerateResponse(prompt, { size });
+    if (filepath) setLastSdxlPath(sender, filepath);
     const capPrompt = prompt.length > 200 ? `${prompt.slice(0, 197)}…` : prompt;
     await sock.sendMessage(sender, {
       image: buffer,
       caption: `SDXL Turbo (${size}): ${capPrompt}`,
     });
+    await sock.sendMessage(sender, { text: iterationHint(filepath ? path.basename(filepath) : null) });
   } catch (e) {
     await sock.sendMessage(sender, {
       text: `SDXL Turbo generation failed: ${e?.message || String(e)}`,
     });
   }
 }
-

--- a/whatsapp/orchestration/createMessageOrchestrator.js
+++ b/whatsapp/orchestration/createMessageOrchestrator.js
@@ -10,7 +10,7 @@ const DEFAULT_BUTTONS = ['a', 'b', 'up', 'down', 'left', 'right', 'start', 'sele
  * @param {{ writeButton(button: string): Promise<void> }} ports.buttonSink
  * @param {{ get(chatId: string): Promise<Array<{ role: 'user'|'assistant'; content: string }>>; append(chatId: string, role: 'user'|'assistant', content: string): Promise<void>; clear(chatId: string): Promise<number> }} ports.chatMemory
  * @param {{ visionText(b64: string): Promise<string>; visionTextHigh(b64: string): Promise<string>; visionHelp(b64: string): Promise<string>; assistant(userText: string, prior: Array<{ role: 'user'|'assistant'; content: string }>): Promise<string> }} ports.ai
- * @param {{ runSpritePlus(m: InboundMessage): Promise<{ handled: boolean }>; runCommandByFirstToken(m: InboundMessage): Promise<{ handled: boolean }>; runLegacyRoutes(m: InboundMessage): Promise<{ handled: boolean }> }} ports.routes
+ * @param {{ runSpritePlus(m: InboundMessage): Promise<{ handled: boolean }>; runSdxlPlus(m: InboundMessage): Promise<{ handled: boolean }>; runCommandByFirstToken(m: InboundMessage): Promise<{ handled: boolean }>; runLegacyRoutes(m: InboundMessage): Promise<{ handled: boolean }> }} ports.routes
  * @param {{ tryHandle(m: InboundMessage): Promise<{ handled: boolean; replyText?: string }> }} ports.agents
  * @param {{ info: Function; warn: Function; error: Function }} ports.logger
  * @param {{ labels: string[] }} [ports.buttons]
@@ -68,6 +68,11 @@ export function createMessageOrchestrator(ports) {
 
     if (/^\s*sprite\+/i.test(m.text)) {
       const r = await ports.routes.runSpritePlus(m);
+      if (r.handled) return;
+    }
+
+    if (/^\s*sdxl\+/i.test(m.text)) {
+      const r = await ports.routes.runSdxlPlus(m);
       if (r.handled) return;
     }
 

--- a/whatsapp/orchestration/createProductionPorts.js
+++ b/whatsapp/orchestration/createProductionPorts.js
@@ -1,5 +1,6 @@
 import restartCommand from '../commands/restart.js';
 import { spriteIterateCommand } from '../commands/sprite.js';
+import { sdxlIterateCommand } from '../commands/sdxl.js';
 import { lidExtraJidsHint } from '../whatsAppActorAllowlist.js';
 import { getWeatherData, deepInfraAPI, vision, visionQuality, visionHelp, assistantgenerateResponse } from '../../models/models.js';
 import { pickRandomTopic } from '../../data/helper.js';
@@ -117,6 +118,10 @@ export function createProductionPorts(deps) {
     routes: {
       async runSpritePlus(m) {
         await spriteIterateCommand(sock, m.chatId, m.text);
+        return { handled: true };
+      },
+      async runSdxlPlus(m) {
+        await sdxlIterateCommand(sock, m.chatId, m.text);
         return { handled: true };
       },
       async runCommandByFirstToken(m) {

--- a/whatsapp/sdxlLastPath.js
+++ b/whatsapp/sdxlLastPath.js
@@ -1,0 +1,39 @@
+import { resolveGeneratedPngBasename } from './spriteLastPath.js';
+
+const TTL_MS = parseInt(process.env.SDXL_LAST_PATH_TTL_MS || String(24 * 60 * 60 * 1000), 10);
+
+/** @type {Map<string, { path: string, at: number }>} */
+const store = new Map();
+
+/**
+ * @param {string} jid
+ * @param {string} absPath absolute path written under assets/generated
+ */
+export function setLastSdxlPath(jid, absPath) {
+  if (!jid || !absPath) return;
+  store.set(jid, { path: absPath, at: Date.now() });
+}
+
+/**
+ * @param {string} jid
+ * @returns {string | null} absolute path or null if missing / expired
+ */
+export function getLastSdxlPath(jid) {
+  if (!jid) return null;
+  const row = store.get(jid);
+  if (!row) return null;
+  if (Date.now() - row.at > TTL_MS) {
+    store.delete(jid);
+    return null;
+  }
+  return row.path;
+}
+
+/**
+ * Resolve a user-supplied basename to a real file under assets/generated (branch from an older step).
+ * @param {string} basename e.g. 2026-03-23T00-08-06-174Z_sdxl_1024x1024_foo.png
+ * @returns {Promise<string>} absolute path
+ */
+export async function resolveSdxlGeneratedPngBasename(basename) {
+  return resolveGeneratedPngBasename(basename);
+}


### PR DESCRIPTION
Fixes #54

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-54-feat-track-last-sdxl-image-per-chat-for-iteratio`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #54

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/54
**State:** OPEN
**Title:** feat: track last SDXL image per chat for iteration

## Body
## What to build
Persist (in-memory is OK initially, like sprite) the last SDXL-related image path per WhatsApp chat, so users can run iterative edits without re-uploading.

This should work as a chain: when an edit produces a new image, update the last-image pointer to that new file so subsequent `sdxl+` edits iterate on the latest output.

## Acceptance criteria
- [ ] Add a small utility similar to `spriteLastPath` to store/get the last SDXL image filepath per chatId
- [ ] Ensure it stores the result from the initial `sdxl` generation and every subsequent iteration
- [ ] Provide a helper to resolve an explicit `filename.png` under `assets/generated` (to allow branching from older steps later)

## Blocked by
None - can start immediately