### PR TITLE
feat: feat: add sdxl+ command to edit/iterate SDXL images (#55)

### DIFF
--- a/test/sdxlIterateCommand.test.js
+++ b/test/sdxlIterateCommand.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sdxlIterateCommand } from '../whatsapp/commands/sdxl.js';
+
+const JID = '15550001111@s.whatsapp.net';
+
+describe('sdxlIterateCommand (sdxl+)', () => {
+  it('sends usage when called with no change request after sdxl+', async () => {
+    /** @type {string[]} */
+    const texts = [];
+    const sock = {
+      sendMessage: async (/** @type {string} */ _jid, /** @type {{ text?: string }} */ content) => {
+        if (content?.text != null) texts.push(String(content.text));
+      },
+    };
+
+    await sdxlIterateCommand(sock, JID, 'sdxl+');
+    await sdxlIterateCommand(sock, JID, '  SDXL+  \t ');
+
+    assert.equal(texts.length, 2);
+    for (const t of texts) {
+      assert.match(t, /SDXL refine/i);
+      assert.match(t, /\*sdxl\+\* <what to change>/i);
+    }
+  });
+
+  it('sends a friendly message when there is no last SDXL image for this chat', async () => {
+    /** @type {string[]} */
+    const texts = [];
+    const sock = {
+      sendMessage: async (/** @type {string} */ _jid, /** @type {{ text?: string }} */ content) => {
+        if (content?.text != null) texts.push(String(content.text));
+      },
+    };
+
+    await sdxlIterateCommand(sock, JID, 'sdxl+ add more contrast');
+
+    assert.equal(texts.length, 1);
+    assert.match(texts[0], /No recent SDXL image/i);
+    assert.match(texts[0], /sdxl/i);
+    assert.match(texts[0], /filename\.png/i);
+  });
+});

--- a/whatsapp/commands/sdxl.js
+++ b/whatsapp/commands/sdxl.js
@@ -89,7 +89,7 @@ export async function sdxlIterateCommand(sock, sender, text) {
     return;
   }
 
-  await sock.sendMessage(sender, { text: 'Refining SDXL image…' });
+  await sock.sendMessage(sender, { text: 'Editing…' });
 
   try {
     const { buffer, filepath } = await qwenImageEditGenerateResponse({


### PR DESCRIPTION
Fixes #55

Opened automatically after a `cursor issue:…` run from the WhatsApp bot.

**Branch:** `cursor/issue-55-feat-add-sdxl-command-to-edit-iterate-sdxl-image`
**Base:** `main`

**Original prompt (truncated):**

# GitHub issue #55

**Repository:** alexisNorthcoders/WhatsappBot
**URL:** https://github.com/alexisNorthcoders/WhatsappBot/issues/55
**State:** OPEN
**Title:** feat: add sdxl+ command to edit/iterate SDXL images

## Body
## What to build
Add a WhatsApp command `sdxl+` that edits the last SDXL image in the current chat using DeepInfra `images/edits` with model `Qwen/Qwen-Image-Edit`.

Command shapes:
- `sdxl+ <change request>` → edits the last SDXL image for this chat
- (optional) `sdxl+ <filename.png> <change request>` → edits a specific file under `assets/generated`

On success, send the edited image back to WhatsApp and update “last SDXL image” so users can iterate repeatedly.

## Acceptance criteria
- [ ] `sdxl+` sends an acknowledgement message (e.g. “Editing…”) then sends the resulting image
- [ ] Uses `Qwen/Qwen-Image-Edit` via `POST /v1/openai/images/edits`
- [ ] Updates last-image pointer to the new output, enabling iterative chains (`sdxl+` after `sdxl+`)
- [ ] Handles missing last-image with a friendly usage message
- [ ] Basic tests for parsing/UX (at least: no-args usage, no-last-image error path)

## Blocked by
- Blocked by #53
- Blocked by #54